### PR TITLE
Enable recursive submodule checkout in community submission workflow

### DIFF
--- a/.github/workflows/community-submission.yml
+++ b/.github/workflows/community-submission.yml
@@ -65,6 +65,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          submodules: recursive
 
       - name: Validate description.yml schema
         id: schema


### PR DESCRIPTION
## Summary
Updated the community submission GitHub Actions workflow to recursively checkout submodules when cloning the repository.

## Changes
- Added `submodules: recursive` option to the `actions/checkout` step in the community-submission workflow
  - This ensures that any nested submodules are also cloned during the checkout process
  - Allows the workflow to access and validate content from submodule dependencies

## Details
This change enables the workflow to properly handle repositories that contain submodules, ensuring all nested dependencies are available when running the description.yml schema validation and other workflow steps.

https://claude.ai/code/session_019PgSnLjDfjy5rzfsjDEdus