### PR TITLE
Increase Quality Gate job timeout to 30 minutes

### DIFF
--- a/.github/workflows/community-submission.yml
+++ b/.github/workflows/community-submission.yml
@@ -209,7 +209,7 @@ jobs:
     name: Quality Gate
     needs: validate
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: dtolnay/rust-toolchain@stable

--- a/description.yml
+++ b/description.yml
@@ -15,7 +15,7 @@ extension:
 
 repo:
   github: tomtom215/duckdb-behavioral
-  ref: d0a7a13751fda8547d478dd14a1d86e261c27575
+  ref: 0372752254ec1bf9791013db5e595588f396d14d
 
 docs:
   hello_world: |


### PR DESCRIPTION
## Summary
Increased the timeout for the Quality Gate CI job to accommodate longer build and test execution times.

## Changes
- **CI/CD**: Extended `quality-gate` job timeout from 15 minutes to 30 minutes in the community submission workflow
- **Dependencies**: Updated duckdb-behavioral repository reference to latest commit

## Details
The Quality Gate job performs validation checks that may require additional time to complete, particularly for comprehensive testing and quality analysis. Doubling the timeout from 15 to 30 minutes provides a more reliable margin to prevent premature job cancellation while maintaining reasonable CI/CD feedback cycles.

https://claude.ai/code/session_01Nzsc51HKxDeQ78VgyUftEH