### PR TITLE
Upgrade to DuckDB v1.5.0 and quack-rs v0.6.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -28,7 +28,7 @@ What actually happened. Include any error messages.
 
 ## Environment
 
-- **DuckDB version**: (e.g., v1.4.4)
+- **DuckDB version**: (e.g., v1.5.0)
 - **Extension version**: (e.g., v0.2.0 or built from source)
 - **OS**: (e.g., Ubuntu 24.04, macOS 15, Windows 11)
 - **Architecture**: (e.g., x86_64, aarch64)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,7 +132,7 @@ jobs:
       - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
 
       - name: Install cargo-nextest
-        uses: taiki-e/install-action@d6e286fa45544157a02d45a43742857ebbc25d12 # v2
+        uses: taiki-e/install-action@a37010ded18ff788be4440302bd6830b1ae50d8b # v2
         with:
           tool: cargo-nextest
 
@@ -203,7 +203,7 @@ jobs:
       - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
 
       - name: Install cargo-nextest
-        uses: taiki-e/install-action@d6e286fa45544157a02d45a43742857ebbc25d12 # v2
+        uses: taiki-e/install-action@a37010ded18ff788be4440302bd6830b1ae50d8b # v2
         with:
           tool: cargo-nextest
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -49,7 +49,7 @@ jobs:
           echo "Default Setup state: ${state} (no conflict)"
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@c793b717bc78562f491db7b0e93a3a178b099162 # v4.32.5
+        uses: github/codeql-action/init@0d579ffd059c29b07949a3cce3983f0780820c98 # v4.32.6
         with:
           languages: rust
           # Use the default query suite for comprehensive coverage
@@ -58,9 +58,9 @@ jobs:
       # CodeQL for compiled languages needs a build step.
       # Autobuild attempts to build the project automatically.
       - name: Autobuild
-        uses: github/codeql-action/autobuild@c793b717bc78562f491db7b0e93a3a178b099162 # v4.32.5
+        uses: github/codeql-action/autobuild@0d579ffd059c29b07949a3cce3983f0780820c98 # v4.32.6
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@c793b717bc78562f491db7b0e93a3a178b099162 # v4.32.5
+        uses: github/codeql-action/analyze@0d579ffd059c29b07949a3cce3983f0780820c98 # v4.32.6
         with:
           category: "/language:rust"

--- a/.github/workflows/community-submission.yml
+++ b/.github/workflows/community-submission.yml
@@ -459,7 +459,7 @@ jobs:
           ### Testing
 
           - 453 unit tests + 1 doc-test
-          - 27 E2E tests against real DuckDB v1.4.4
+          - 27 E2E tests against real DuckDB v1.5.0
           - 7 SQL integration test files in test/sql/
           - Criterion.rs benchmarks up to 1 billion elements
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -22,7 +22,7 @@ env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: -Dwarnings
   RUST_BACKTRACE: 1
-  DUCKDB_VERSION: "v1.4.4"
+  DUCKDB_VERSION: "v1.5.0"
 
 jobs:
   e2e-test:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -179,7 +179,7 @@ jobs:
           tar czf "${{ env.EXTENSION_NAME }}-${{ needs.validate.outputs.version }}-${{ matrix.platform }}.tar.gz" -C dist .
 
       - name: Generate artifact attestation
-        uses: actions/attest-build-provenance@96278af6caaf10aea03fd8d33a09a777ca52d62f # v3.2.0
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
           subject-path: ${{ env.EXTENSION_NAME }}-${{ needs.validate.outputs.version }}-${{ matrix.platform }}.tar.gz
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,7 +59,7 @@ src/
    submodules handle DuckDB C API registration only.
 
 2. **Aggregate functions via quack-rs SDK**: DuckDB's Rust crate does not yet
-   provide high-level aggregate function registration. We use `quack-rs` v0.5.0
+   provide high-level aggregate function registration. We use `quack-rs` v0.6.0
    ([crates.io](https://crates.io/crates/quack-rs)) which wraps the raw C API with safe builders
    (`AggregateFunctionSetBuilder`), state management (`FfiState<T>`), vector I/O
    (`VectorReader`/`VectorWriter` including `write_varchar`), complex type helpers
@@ -150,20 +150,24 @@ duckdb -unsigned -c "LOAD '/tmp/behavioral.duckdb_extension'; SELECT ..."
 ## Dependencies
 
 **Runtime** (linked into the `.so`/`.dylib`):
-- `quack-rs` v0.5.0 ([crates.io](https://crates.io/crates/quack-rs)) — Rust SDK
+- `quack-rs` v0.6.0 ([crates.io](https://crates.io/crates/quack-rs)) — Rust SDK
   for DuckDB loadable extensions. Provides `entry_point!` macro,
   `AggregateFunctionSetBuilder` (with `returns_logical(LogicalType)` for `LIST(T)` returns),
   `FfiState<T>`, `VectorReader`/`VectorWriter` (including `write_varchar`),
   `ListVector` for LIST output, `LogicalType::list()` for parameterized types,
   and `AggregateTestHarness` for combine testing. Re-exports `libduckdb-sys`
   with `loadable-extension` feature.
-- `libduckdb-sys = "=1.4.4"` with `loadable-extension` feature — Kept explicitly
+- `libduckdb-sys = "=1.10500.0"` with `loadable-extension` feature — Kept explicitly
   for `sessionize` FFI (window function not supported by quack-rs). Re-exported
   by quack-rs but pinned explicitly for the raw window function callbacks.
+  Note: crate versioning uses `1.MAJOR_MINOR_PATCH.x` scheme (DuckDB v1.5.0 →
+  crate v1.10500.x).
 
 **Dev-only** (unit tests and benchmarks):
-- `duckdb = "=1.4.4"` with `bundled` feature — Used in `#[cfg(test)]` modules
+- `duckdb = "=1.10500.0"` with `bundled` feature — Used in `#[cfg(test)]` modules
   for `Connection::open_in_memory()`. Not linked into the release extension.
+  Note: crate versioning uses `1.MAJOR_MINOR_PATCH.x` scheme (DuckDB v1.5.0 →
+  crate v1.10500.x).
 - `criterion = "0.8"` with `html_reports` feature — Statistical benchmarking
 - `proptest = "1"` — Property-based testing
 
@@ -189,7 +193,7 @@ Every change MUST meet these requirements:
   ClickHouse mode combinations, and `AggregateTestHarness` combine
   config-propagation tests for all 5 aggregate functions
 - **1 doc-test** for the pattern parser
-- **27 E2E tests** against real DuckDB v1.4.4 CLI covering all 7 functions
+- **27 E2E tests** against real DuckDB v1.5.0 CLI covering all 7 functions
   with multiple scenarios (basic, timeout, modes, GROUP BY, no-match, NULL
   inputs, empty tables, all funnel modes, 5+ conditions, all 8
   direction/base combinations)
@@ -378,7 +382,7 @@ Hard-won knowledge from developing this extension. Consult before making changes
   to it produces garbage instead of NULL. `VectorWriter::set_null()` handles this
   automatically.
 
-- **Extension metadata version is C API version, not DuckDB version**: DuckDB v1.4.4
+- **Extension metadata version is C API version, not DuckDB version**: DuckDB v1.5.0
   uses C API version `v1.2.0`. The `append_extension_metadata.py -dv` flag must use
   the C API version, not the release version.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ cargo fmt -- --check           # Format check
 
 - Rust 1.84.1+ (the project's MSRV)
 - A C compiler (for DuckDB system bindings)
-- DuckDB CLI v1.4.4 (for E2E testing)
+- DuckDB CLI v1.5.0 (for E2E testing)
 
 ## Key Principles
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1581,9 +1581,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.13"
+version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,9 +95,9 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "arrow"
-version = "56.2.0"
+version = "57.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e833808ff2d94ed40d9379848a950d995043c7fb3e81a30b383f4c6033821cc"
+checksum = "e4754a624e5ae42081f464514be454b39711daae0458906dacde5f4c632f33a8"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -113,23 +113,23 @@ dependencies = [
 
 [[package]]
 name = "arrow-arith"
-version = "56.2.0"
+version = "57.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad08897b81588f60ba983e3ca39bda2b179bdd84dced378e7df81a5313802ef8"
+checksum = "f7b3141e0ec5145a22d8694ea8b6d6f69305971c4fa1c1a13ef0195aef2d678b"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
  "arrow-data",
  "arrow-schema",
  "chrono",
- "num",
+ "num-traits",
 ]
 
 [[package]]
 name = "arrow-array"
-version = "56.2.0"
+version = "57.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8548ca7c070d8db9ce7aa43f37393e4bfcf3f2d3681df278490772fd1673d08d"
+checksum = "4c8955af33b25f3b175ee10af580577280b4bd01f7e823d94c7cdef7cf8c9aef"
 dependencies = [
  "ahash 0.8.12",
  "arrow-buffer",
@@ -138,29 +138,33 @@ dependencies = [
  "chrono",
  "half",
  "hashbrown 0.16.1",
- "num",
+ "num-complex",
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
 name = "arrow-buffer"
-version = "56.2.0"
+version = "57.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e003216336f70446457e280807a73899dd822feaf02087d31febca1363e2fccc"
+checksum = "c697ddca96183182f35b3a18e50b9110b11e916d7b7799cbfd4d34662f2c56c2"
 dependencies = [
  "bytes",
  "half",
- "num",
+ "num-bigint",
+ "num-traits",
 ]
 
 [[package]]
 name = "arrow-cast"
-version = "56.2.0"
+version = "57.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "919418a0681298d3a77d1a315f625916cb5678ad0d74b9c60108eb15fd083023"
+checksum = "646bbb821e86fd57189c10b4fcdaa941deaf4181924917b0daa92735baa6ada5"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
  "arrow-data",
+ "arrow-ord",
  "arrow-schema",
  "arrow-select",
  "atoi",
@@ -169,27 +173,28 @@ dependencies = [
  "comfy-table",
  "half",
  "lexical-core",
- "num",
+ "num-traits",
  "ryu",
 ]
 
 [[package]]
 name = "arrow-data"
-version = "56.2.0"
+version = "57.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5c64fff1d142f833d78897a772f2e5b55b36cb3e6320376f0961ab0db7bd6d0"
+checksum = "1fdd994a9d28e6365aa78e15da3f3950c0fdcea6b963a12fa1c391afb637b304"
 dependencies = [
  "arrow-buffer",
  "arrow-schema",
  "half",
- "num",
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
 name = "arrow-ord"
-version = "56.2.0"
+version = "57.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c8f82583eb4f8d84d4ee55fd1cb306720cddead7596edce95b50ee418edf66f"
+checksum = "f7d8f1870e03d4cbed632959498bcc84083b5a24bded52905ae1695bd29da45b"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -200,9 +205,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-row"
-version = "56.2.0"
+version = "57.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d07ba24522229d9085031df6b94605e0f4b26e099fb7cdeec37abd941a73753"
+checksum = "18228633bad92bff92a95746bbeb16e5fc318e8382b75619dec26db79e4de4c0"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -213,32 +218,32 @@ dependencies = [
 
 [[package]]
 name = "arrow-schema"
-version = "56.2.0"
+version = "57.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3aa9e59c611ebc291c28582077ef25c97f1975383f1479b12f3b9ffee2ffabe"
+checksum = "8c872d36b7bf2a6a6a2b40de9156265f0242910791db366a2c17476ba8330d68"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "arrow-select"
-version = "56.2.0"
+version = "57.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c41dbbd1e97bfcaee4fcb30e29105fb2c75e4d82ae4de70b792a5d3f66b2e7a"
+checksum = "68bf3e3efbd1278f770d67e5dc410257300b161b93baedb3aae836144edcaf4b"
 dependencies = [
  "ahash 0.8.12",
  "arrow-array",
  "arrow-buffer",
  "arrow-data",
  "arrow-schema",
- "num",
+ "num-traits",
 ]
 
 [[package]]
 name = "arrow-string"
-version = "56.2.0"
+version = "57.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53f5183c150fbc619eede22b861ea7c0eebed8eaac0333eaa7f6da5205fd504d"
+checksum = "85e968097061b3c0e9fe3079cf2e703e487890700546b5b0647f60fca1b5a8d8"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -246,7 +251,7 @@ dependencies = [
  "arrow-schema",
  "arrow-select",
  "memchr",
- "num",
+ "num-traits",
  "regex",
  "regex-syntax",
 ]
@@ -597,9 +602,9 @@ dependencies = [
 
 [[package]]
 name = "duckdb"
-version = "1.4.4"
+version = "1.10500.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8685352ce688883098b61a361e86e87df66fc8c444f4a2411e884c16d5243a65"
+checksum = "6a2048e4963a37ec458d9e93444192e0e949ac0a188d201ea53472f2c42db822"
 dependencies = [
  "arrow",
  "cast",
@@ -1225,9 +1230,9 @@ checksum = "459427e2af2b9c839b132acb702a1c654d95e10f8c326bfc2ad11310e458b1c5"
 
 [[package]]
 name = "libduckdb-sys"
-version = "1.4.4"
+version = "1.10500.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d78bacb8933586cee3b550c39b610d314f9b7a48701ac7a914a046165a4ad8da"
+checksum = "6df9db064ff17120305ec6b7aee048f766cdf2a3ce9ffbb6953aaa3634605030"
 dependencies = [
  "cc",
  "flate2",
@@ -1312,20 +1317,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
-dependencies = [
- "num-bigint",
- "num-complex",
- "num-integer",
- "num-iter",
- "num-rational",
- "num-traits",
-]
-
-[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1350,28 +1341,6 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "num-iter"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-rational"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
-dependencies = [
- "num-bigint",
- "num-integer",
  "num-traits",
 ]
 
@@ -1546,10 +1515,11 @@ dependencies = [
 
 [[package]]
 name = "quack-rs"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7dfc0521df3c2d1e7889156a509d20aeecacdc571811229c4ef9278964fbd1b"
+checksum = "c7ac9c243df54ceae492f3cd0b2ce810ed88e6bd4e506ddf1096979b94b9f564"
 dependencies = [
+ "cc",
  "libduckdb-sys",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,11 +20,11 @@ name = "behavioral"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-quack-rs = "0.5.0"
-libduckdb-sys = { version = "=1.4.4", features = ["loadable-extension"] }
+quack-rs = "0.6.0"
+libduckdb-sys = { version = "=1.10500.0", features = ["loadable-extension"] }
 
 [dev-dependencies]
-duckdb = { version = "=1.4.4", features = ["bundled"] }
+duckdb = { version = "=1.10500.0", features = ["bundled"] }
 criterion = { version = "0.8", features = ["html_reports"] }
 proptest = "1"
 

--- a/Makefile
+++ b/Makefile
@@ -10,11 +10,11 @@ EXTENSION_NAME=behavioral
 # Required: duckdb-rs relies on unstable C API functionality
 USE_UNSTABLE_C_API=1
 
-# Target DuckDB version (must match duckdb = "=1.4.4" pin in Cargo.toml)
-TARGET_DUCKDB_VERSION=v1.4.4
+# Target DuckDB version (must match duckdb = "=1.10500.0" pin in Cargo.toml)
+TARGET_DUCKDB_VERSION=v1.5.0
 
 # Pin the test runner to the same DuckDB version (extension-ci-tools defaults to latest)
-DUCKDB_TEST_VERSION=1.4.4
+DUCKDB_TEST_VERSION=1.5.0
 
 all: configure debug
 

--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ for the full SemVer rules applied to SQL function signatures.
 ## Requirements
 
 - Rust 1.84.1+ (MSRV)
-- DuckDB 1.4.4 (pinned dependency)
+- DuckDB 1.5.0 (pinned dependency)
 - Python 3.x (for extension metadata tooling)
 
 ## License

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -31,8 +31,8 @@ safe Rust. Every `unsafe` block has a `// SAFETY:` documentation comment.
 
 ### Dependency Audit
 
-The extension has exactly **two** runtime dependencies (`quack-rs = "=0.3.0"`
-and `libduckdb-sys = "=1.4.4"`, both pinned exactly). All dependencies are
+The extension has exactly **two** runtime dependencies (`quack-rs = "=0.6.0"`
+and `libduckdb-sys = "=1.10500.0"`, both pinned exactly). All dependencies are
 audited via `cargo-deny` in CI for known advisories and license compliance.
 
 ### Build Integrity

--- a/docs/src/contributing.md
+++ b/docs/src/contributing.md
@@ -8,7 +8,7 @@ Guidelines for contributing to `duckdb-behavioral`.
 
 - Rust 1.84.1+ (the project's MSRV)
 - A C compiler (for DuckDB system bindings)
-- DuckDB CLI v1.4.4 (for E2E testing)
+- DuckDB CLI v1.5.0 (for E2E testing)
 
 ### Building
 
@@ -46,7 +46,7 @@ configuration and allowed exceptions (FFI callbacks, analytics math casts).
 - **Pure Rust core**: Business logic in top-level modules (`sessionize.rs`,
   `retention.rs`, etc.) with zero FFI dependencies.
 - **FFI bridge via quack-rs SDK**: DuckDB C API registration confined to
-  `src/ffi/`, using [quack-rs](https://crates.io/crates/quack-rs) v0.5.0
+  `src/ffi/`, using [quack-rs](https://crates.io/crates/quack-rs) v0.6.0
   for safe builders (including `returns_logical(LogicalType)` for
   `LIST(T)` returns), state management (`FfiState<T>`), vector I/O
   (`VectorReader`/`VectorWriter`), LIST output (`ListVector`), and type

--- a/docs/src/engineering.md
+++ b/docs/src/engineering.md
@@ -312,7 +312,7 @@ these analyses can run as interactive queries rather than batch jobs.
 
 DuckDB's Rust crate does not provide high-level aggregate function
 registration. This project uses the [quack-rs](https://crates.io/crates/quack-rs)
-SDK (v0.5.0) which wraps the raw C API with safe builders
+SDK (v0.6.0) which wraps the raw C API with safe builders
 (including `returns_logical(LogicalType)` for `LIST(T)` return types),
 state management, vector I/O, and LIST output helpers. All 6 aggregate
 functions use the builder for registration. The `sessionize` function
@@ -427,7 +427,7 @@ incorrect results that passed all unit tests but failed E2E validation.
 | Layer | Technology | Purpose |
 |---|---|---|
 | Language | Rust (stable, MSRV 1.84.1) | Memory safety, zero-cost abstractions, `unsafe` confinement |
-| Database | DuckDB 1.4.4 | Analytical SQL engine, segment tree windowing |
+| Database | DuckDB 1.5.0 | Analytical SQL engine, segment tree windowing |
 | FFI | libduckdb-sys (C API) | Raw aggregate function registration |
 | Benchmarking | Criterion.rs | Statistical benchmarking with confidence intervals |
 | Property testing | proptest | Algebraic property verification |

--- a/docs/src/faq.md
+++ b/docs/src/faq.md
@@ -42,7 +42,7 @@ duckdb -unsigned -c "LOAD 'target/release/libbehavioral.so'; SELECT ..."
 ### The extension fails to load. What should I check?
 
 1. **DuckDB version mismatch**: The community extension is built for DuckDB
-   v1.4.4. If you are using a different DuckDB version, the extension may not
+   v1.5.0. If you are using a different DuckDB version, the extension may not
    be available for that version yet. For locally-built extensions, the C API
    version must match (currently `v1.2.0`).
 

--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -31,7 +31,7 @@ platform where Rust and DuckDB are available.
 
 - Rust 1.84.1 or later (`rustup` recommended)
 - A C compiler (gcc, clang, or MSVC -- needed for DuckDB system bindings)
-- DuckDB CLI v1.4.4 (for running queries)
+- DuckDB CLI v1.5.0 (for running queries)
 
 **Build steps:**
 
@@ -289,14 +289,14 @@ matched Home -> Product sequence.
 **"file was built for DuckDB C API version '...' but we can only load extensions built for DuckDB C API '...'"**
 
 The extension is built against DuckDB C API version `v1.2.0` (used by DuckDB
-v1.4.4). You must use a DuckDB CLI version that matches. Check your version
+v1.5.0). You must use a DuckDB CLI version that matches. Check your version
 with:
 
 ```bash
 duckdb --version
 ```
 
-If you see a different version, either install DuckDB v1.4.4 or rebuild the
+If you see a different version, either install DuckDB v1.5.0 or rebuild the
 extension against your DuckDB version (this requires updating the
 `libduckdb-sys` dependency in `Cargo.toml`).
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -264,7 +264,7 @@ For a comprehensive technical overview, see the
 
 ## Requirements
 
-- **DuckDB 1.4.4** (C API version v1.2.0)
+- **DuckDB 1.5.0** (C API version v1.2.0)
 - **Rust 1.84.1+** (MSRV) for building from source
 - A C compiler for DuckDB system bindings
 

--- a/docs/src/internals/architecture.md
+++ b/docs/src/internals/architecture.md
@@ -86,7 +86,7 @@ versions.
 
 ### quack-rs SDK
 
-The FFI layer uses [quack-rs](https://crates.io/crates/quack-rs) v0.5.0,
+The FFI layer uses [quack-rs](https://crates.io/crates/quack-rs) v0.6.0,
 a Rust SDK for DuckDB loadable extensions. It provides:
 
 - **`AggregateFunctionSetBuilder`**: Safe registration of function sets with

--- a/docs/src/internals/performance.md
+++ b/docs/src/internals/performance.md
@@ -187,7 +187,7 @@ Discovered and fixed 3 critical bugs that all 375 passing unit tests at the time
    time.
 
 No performance optimization targets. 11 E2E tests added against real DuckDB
-v1.4.4 CLI.
+v1.5.0 CLI.
 
 ### NFA Fast Paths
 

--- a/docs/src/operations/security.md
+++ b/docs/src/operations/security.md
@@ -34,8 +34,8 @@ The extension has exactly **two** runtime dependencies:
 
 | Crate | Version | Purpose |
 |-------|---------|---------|
-| `quack-rs` | `=0.3.0` | Rust SDK for DuckDB loadable extensions — entry point macro, aggregate builders, safe state management, vector I/O |
-| `libduckdb-sys` | `=1.4.4` | DuckDB C API bindings (re-exported by quack-rs; kept explicitly for `sessionize` window function FFI) |
+| `quack-rs` | `=0.6.0` | Rust SDK for DuckDB loadable extensions — entry point macro, aggregate builders, safe state management, vector I/O |
+| `libduckdb-sys` | `=1.10500.0` | DuckDB C API bindings (re-exported by quack-rs; kept explicitly for `sessionize` window function FFI) |
 
 Both versions are **pinned exactly** to prevent silent dependency updates.
 `quack-rs` provides `entry_point!`, `AggregateFunctionSetBuilder`,

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -106,7 +106,7 @@ find_duckdb() {
 }
 
 install_duckdb() {
-    log_info "DuckDB CLI not found. Installing v1.4.4..."
+    log_info "DuckDB CLI not found. Installing v1.5.0..."
 
     local os
     local arch
@@ -115,13 +115,13 @@ install_duckdb() {
 
     local url=""
     if [[ "${os}" == "linux" && "${arch}" == "x86_64" ]]; then
-        url="https://github.com/duckdb/duckdb/releases/download/v1.4.4/duckdb_cli-linux-amd64.zip"
+        url="https://github.com/duckdb/duckdb/releases/download/v1.5.0/duckdb_cli-linux-amd64.zip"
     elif [[ "${os}" == "linux" && "${arch}" == "aarch64" ]]; then
-        url="https://github.com/duckdb/duckdb/releases/download/v1.4.4/duckdb_cli-linux-aarch64.zip"
+        url="https://github.com/duckdb/duckdb/releases/download/v1.5.0/duckdb_cli-linux-aarch64.zip"
     elif [[ "${os}" == "darwin" && "${arch}" == "x86_64" ]]; then
-        url="https://github.com/duckdb/duckdb/releases/download/v1.4.4/duckdb_cli-osx-universal.zip"
+        url="https://github.com/duckdb/duckdb/releases/download/v1.5.0/duckdb_cli-osx-universal.zip"
     elif [[ "${os}" == "darwin" && "${arch}" == "arm64" ]]; then
-        url="https://github.com/duckdb/duckdb/releases/download/v1.4.4/duckdb_cli-osx-universal.zip"
+        url="https://github.com/duckdb/duckdb/releases/download/v1.5.0/duckdb_cli-osx-universal.zip"
     else
         log_err "Unsupported platform: ${os}/${arch}"
         return 1

--- a/src/ffi/mod.rs
+++ b/src/ffi/mod.rs
@@ -5,7 +5,7 @@
 //!
 //! # Architecture
 //!
-//! All modules except [`sessionize`] use the `quack-rs` v0.5.0 SDK for
+//! All modules except [`sessionize`] use the `quack-rs` v0.6.0 SDK for
 //! registration, state management, and vector I/O:
 //!
 //! - [`quack_rs::aggregate::AggregateFunctionSetBuilder`] — registers function


### PR DESCRIPTION
## Summary

Updates the project to use DuckDB v1.5.0 (C API v1.2.0) and quack-rs v0.6.0. This is a dependency upgrade that maintains API compatibility while bringing in upstream improvements and bug fixes.

## Changes

- **Cargo.toml**: Updated `quack-rs` from v0.5.0 to v0.6.0, `libduckdb-sys` from v1.4.4 to v1.10500.0, and `duckdb` dev-dependency from v1.4.4 to v1.10500.0
  - Note: DuckDB crate versioning uses `1.MAJOR_MINOR_PATCH.x` scheme (DuckDB v1.5.0 → crate v1.10500.x)
- **Makefile**: Updated `TARGET_DUCKDB_VERSION` to v1.5.0 and `DUCKDB_TEST_VERSION` to 1.5.0
- **scripts/setup.sh**: Updated DuckDB CLI installation URLs and version references to v1.5.0 for all platforms (Linux x86_64/aarch64, macOS universal)
- **Documentation**: Updated all references to DuckDB version from v1.4.4 to v1.5.0 across:
  - CLAUDE.md (architecture, dependencies, testing notes)
  - docs/src/getting-started.md, contributing.md, engineering.md, faq.md, index.md, internals/
  - CONTRIBUTING.md, README.md, SECURITY.md
- **CI/CD**: Updated `.github/workflows/e2e.yml` and community-submission.yml to use DuckDB v1.5.0
- **Issue templates**: Updated bug report template to reference v1.5.0 as example version
- **Source code**: Updated FFI module documentation in `src/ffi/mod.rs` to reference quack-rs v0.6.0

## Testing

- [ ] `cargo test` passes (453 unit tests + 1 doc-test)
- [ ] `cargo clippy --all-targets` produces zero warnings
- [ ] `cargo fmt -- --check` passes
- [ ] E2E tests pass against DuckDB v1.5.0 (27 tests)

## Notes

The C API version remains v1.2.0 (unchanged from DuckDB v1.4.4 to v1.5.0), so no FFI changes are required. This is a straightforward dependency upgrade with documentation synchronization.

https://claude.ai/code/session_018PhG9emUTWAAe5gKtfJnQW