### PR TITLE
Bump version to 0.3.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "duckdb-behavioral"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 rust-version = "1.84.1"
 authors = ["Tom F <tomtom215@users.noreply.github.com>"]


### PR DESCRIPTION
## Summary

Bump the crate version from 0.2.0 to 0.3.0 to reflect the changes in this release.

## Changes

- Update `duckdb-behavioral` version to 0.3.0 in Cargo.toml

## Testing

- [ ] `cargo test` passes (453 unit tests + 1 doc-test)
- [ ] `cargo clippy --all-targets` produces zero warnings
- [ ] `cargo fmt -- --check` passes

## Notes

This is a routine version bump. No source code changes are included in this commit.

https://claude.ai/code/session_01UVfdAnzCF5JrMCc2PjYaF9