### PR TITLE
Update to DuckDB v1.5.3 / quack-rs 0.13.0 (v0.6.0) + docs accuracy audit

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -28,8 +28,8 @@ What actually happened. Include any error messages.
 
 ## Environment
 
-- **DuckDB version**: (e.g., v1.5.2)
-- **Extension version**: (e.g., v0.5.0 or built from source)
+- **DuckDB version**: (e.g., v1.5.3)
+- **Extension version**: (e.g., v0.6.0 or built from source)
 - **OS**: (e.g., Ubuntu 24.04, macOS 15, Windows 11)
 - **Architecture**: (e.g., x86_64, aarch64)
 - **Loaded with**: `-unsigned` flag / community extension

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -27,5 +27,5 @@ LOAD 'behavioral';
 
 ## Environment
 
-- **DuckDB version**: (e.g., v1.5.2)
+- **DuckDB version**: (e.g., v1.5.3)
 - **Extension version**: (e.g., community or built from source)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -243,15 +243,15 @@ jobs:
 
   # ── MSRV verification ────────────────────────────────────────────────
   msrv:
-    name: MSRV (1.86)
+    name: MSRV (1.87)
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: dtolnay/rust-toolchain@1.86
+      - uses: dtolnay/rust-toolchain@1.87
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
-          key: msrv-1.86
+          key: msrv-1.87
       - name: Check MSRV compilation
         id: msrv-check
         run: cargo check --all-targets
@@ -259,9 +259,9 @@ jobs:
         if: always()
         run: |
           if [ "${{ steps.msrv-check.outcome }}" = "success" ]; then
-            echo "### ✅ MSRV 1.86 compilation verified" >> "$GITHUB_STEP_SUMMARY"
+            echo "### ✅ MSRV 1.87 compilation verified" >> "$GITHUB_STEP_SUMMARY"
           else
-            echo "### ❌ MSRV 1.86 compilation failed" >> "$GITHUB_STEP_SUMMARY"
+            echo "### ❌ MSRV 1.87 compilation failed" >> "$GITHUB_STEP_SUMMARY"
           fi
 
   # ── Benchmark compilation ────────────────────────────────────────────

--- a/.github/workflows/community-submission.yml
+++ b/.github/workflows/community-submission.yml
@@ -459,7 +459,7 @@ jobs:
           ### Testing
 
           - 453 unit tests + 1 doc-test (29 proptest)
-          - 11 E2E workflow test steps per platform against real DuckDB v1.5.2
+          - 11 E2E workflow test steps per platform against real DuckDB v1.5.3
           - 7 SQL integration test files (59 queries) in test/sql/
           - Criterion.rs benchmarks up to 1 billion elements
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -22,7 +22,7 @@ env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: -Dwarnings
   RUST_BACKTRACE: 1
-  DUCKDB_VERSION: "v1.5.2"
+  DUCKDB_VERSION: "v1.5.3"
 
 jobs:
   e2e-test:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,30 @@ all `.github/workflows/*.yml`, `Makefile`, `description.yml`, and the
 issue templates so every cross-reference is consistent with the
 `v0.6.0` / DuckDB `v1.5.3` / quack-rs `v0.13.0` / MSRV `1.87` baseline.
 
+A full accuracy pass over every doc against the source also corrected
+several pre-existing defects unrelated to the version bump:
+
+- **Broken metadata-append examples** in `docs/src/getting-started.md` and
+  `docs/src/contributing.md` stamped `-dv v1.2.0 ... --abi-type C_STRUCT`,
+  which produces an extension DuckDB 1.5.x rejects on load. Corrected to the
+  real `-dv v1.5.3 ... --abi-type C_STRUCT_UNSTABLE` convention.
+- **CI job lists** in `README.md` and `docs/src/engineering.md` claimed "13
+  CI jobs" but enumerated only 12 (omitting `ci-gate`); both now list all 13.
+- **`sequence_next_node` bases** in `docs/src/quick-reference.md` wrongly
+  described `head`/`tail` as aliases of `first_match`/`last_match`; they are
+  four distinct strategies (corrected to match the function reference).
+- **Spurious `rand` dev-dependency** removed from the `docs/src/operations/security.md`
+  dependency table — `rand` is only transitive; benchmarks generate data
+  deterministically.
+- **`attest-build-provenance@v3`** in `docs/src/operations/security.md`
+  corrected to `@v4` (matching `release.yml`), and a stale `v0.2.0`
+  verification example bumped to `v0.6.0`.
+- Cleared stale "DuckDB 1.5.1" and "C API version v1.2.0" references in
+  `README.md`, `docs/src/index.md`, `docs/src/engineering.md`,
+  `docs/src/faq.md`, and `docs/src/getting-started.md`.
+- Aligned the `AggregateTestHarness` config-propagation claim in `CLAUDE.md`
+  to "all 6 aggregate functions" (across 5 FFI test modules).
+
 ## [0.5.0] - 2026-05-01
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-05-24
+
+### Changed
+
+- **DuckDB v1.5.3 support** — upgraded `libduckdb-sys` from `1.10502.0` to
+  `1.10503.1` and `duckdb` (dev) from `1.10502.0` to `1.10503.1`. Restores
+  community-extension compatibility with the current DuckDB release line (the
+  registry had de-listed the extension for targeting an older version)
+- **quack-rs v0.13.0** — upgraded from v0.12.0. The public APIs used by this
+  crate (`AggregateFunctionSetBuilder`, `FfiState`, `VectorReader`/`VectorWriter`,
+  `ListVector`, `LogicalType::list`, `AggregateTestHarness`,
+  `Connection`/`Registrar` trait, `entry_point_v2!`) are unchanged: the crate
+  compiles against the new SDK with **zero source changes**. New upstream
+  capabilities in this range — the `error_data`, `expression`, `file_system`,
+  `appender`, `selection_vector`, and `instance_cache` modules, plus
+  `TypeId::Variant` / `TypeId::Geometry` behind the `duckdb-1-5-3` feature —
+  are available but not consumed: the extension's aggregate-only surface area
+  doesn't exercise them
+- **MSRV bumped from 1.86 to 1.87** — quack-rs v0.13.0 corrected its declared
+  MSRV to 1.87.0 to match `libduckdb-sys`. CI's `cargo check --all-targets`
+  MSRV gate now pins 1.87
+- E2E tests now run against DuckDB v1.5.3 CLI (previously v1.5.2)
+
+### Fixed
+
+- **Version drift in `scripts/setup.sh`** — the DuckDB CLI download URLs
+  hardcoded `v1.5.2` in four places instead of deriving from the
+  `DUCKDB_RELEASE_VERSION` constant. Refactored to build every URL from the
+  single constant, removing a recurring source of stale references
+
+### Documentation
+
+Audited and updated all version/MSRV references across `README.md`,
+`CLAUDE.md`, `CONTRIBUTING.md`, `SECURITY.md`, all of `docs/src/**.md`,
+all `.github/workflows/*.yml`, `Makefile`, `description.yml`, and the
+issue templates so every cross-reference is consistent with the
+`v0.6.0` / DuckDB `v1.5.3` / quack-rs `v0.13.0` / MSRV `1.87` baseline.
+
 ## [0.5.0] - 2026-05-01
 
 ### Changed
@@ -238,7 +276,8 @@ all bumping deps to versions at or below those landed here: #58, #61,
 - 88.4% mutation testing kill rate (cargo-mutants)
 - MIT license
 
-[Unreleased]: https://github.com/tomtom215/duckdb-behavioral/compare/v0.5.0...HEAD
+[Unreleased]: https://github.com/tomtom215/duckdb-behavioral/compare/v0.6.0...HEAD
+[0.6.0]: https://github.com/tomtom215/duckdb-behavioral/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/tomtom215/duckdb-behavioral/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/tomtom215/duckdb-behavioral/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/tomtom215/duckdb-behavioral/compare/v0.2.0...v0.3.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -196,7 +196,8 @@ Every change MUST meet these requirements:
 - **453 unit tests** covering all functions, edge cases, combine associativity,
   property-based testing (proptest), mutation-testing-guided coverage,
   ClickHouse mode combinations, and `AggregateTestHarness` combine
-  config-propagation tests for all 5 aggregate functions
+  config-propagation tests for all 6 aggregate functions (across 5 FFI test
+  modules -- `sequence_match` and `sequence_count` share one state type)
 - **1 doc-test** for the pattern parser
 - **E2E tests** against real DuckDB v1.5.3 CLI: 11 workflow test steps
   (2 platforms) plus 7 SQL integration test files with 59 queries covering
@@ -322,7 +323,7 @@ Run with `cargo test`. All 453 tests + 1 doc-test run in <1 second.
 GitHub Actions workflows in `.github/workflows/`:
 
 - **ci.yml**: check, test, clippy, fmt, doc, MSRV, bench-compile, deny, semver,
-  coverage, cross-platform (Linux + macOS), extension-build
+  coverage, cross-platform (Linux + macOS), extension-build, ci-gate (13 jobs)
 - **codeql.yml**: CodeQL static analysis for Rust (push, PR, weekly schedule)
 - **e2e.yml**: Builds extension, tests all 7 functions against real DuckDB CLI
 - **release.yml**: Builds release artifacts for x86_64 and aarch64 on Linux/macOS,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,7 +59,7 @@ src/
    submodules handle DuckDB C API registration only.
 
 2. **Aggregate functions via quack-rs SDK**: DuckDB's Rust crate does not yet
-   provide high-level aggregate function registration. We use `quack-rs` v0.12.0
+   provide high-level aggregate function registration. We use `quack-rs` v0.13.0
    ([crates.io](https://crates.io/crates/quack-rs)) which wraps the raw C API with safe builders
    (`AggregateFunctionSetBuilder`), state management (`FfiState<T>`), vector I/O
    (`VectorReader`/`VectorWriter` including `write_varchar`), complex type helpers
@@ -133,7 +133,7 @@ cargo build --release
 cp target/release/libbehavioral.so /tmp/behavioral.duckdb_extension
 python3 extension-ci-tools/scripts/append_extension_metadata.py \
   -l /tmp/behavioral.duckdb_extension -n behavioral \
-  -p linux_amd64 -dv v1.5.2 -ev v0.5.0 --abi-type C_STRUCT_UNSTABLE \
+  -p linux_amd64 -dv v1.5.3 -ev v0.6.0 --abi-type C_STRUCT_UNSTABLE \
   -o /tmp/behavioral.duckdb_extension
 # 3. Load and test
 duckdb -unsigned -c "LOAD '/tmp/behavioral.duckdb_extension'; SELECT ..."
@@ -154,7 +154,7 @@ duckdb -unsigned -c "LOAD '/tmp/behavioral.duckdb_extension'; SELECT ..."
 ## Dependencies
 
 **Runtime** (linked into the `.so`/`.dylib`):
-- `quack-rs` v0.12.0 ([crates.io](https://crates.io/crates/quack-rs)) — Rust SDK
+- `quack-rs` v0.13.0 ([crates.io](https://crates.io/crates/quack-rs)) — Rust SDK
   for DuckDB loadable extensions. Provides `entry_point_v2!` macro,
   `Connection`/`Registrar` trait for version-agnostic registration,
   `AggregateFunctionSetBuilder` (with `returns_logical(LogicalType)` for `LIST(T)` returns),
@@ -162,17 +162,17 @@ duckdb -unsigned -c "LOAD '/tmp/behavioral.duckdb_extension'; SELECT ..."
   `ListVector` for LIST output, `LogicalType::list()` for parameterized types,
   and `AggregateTestHarness` for combine testing. Re-exports `libduckdb-sys`
   with `loadable-extension` feature.
-- `libduckdb-sys = "=1.10502.0"` with `loadable-extension` feature — Kept explicitly
+- `libduckdb-sys = "=1.10503.1"` with `loadable-extension` feature — Kept explicitly
   for `sessionize` FFI (window function not supported by quack-rs). Re-exported
   by quack-rs but pinned explicitly for the raw window function callbacks.
-  Note: crate versioning uses `1.MAJOR_MINOR_PATCH.x` scheme (DuckDB v1.5.2 →
-  crate v1.10502.x).
+  Note: crate versioning uses `1.MAJOR_MINOR_PATCH.x` scheme (DuckDB v1.5.3 →
+  crate v1.10503.x).
 
 **Dev-only** (unit tests and benchmarks):
-- `duckdb = "=1.10502.0"` with `bundled` feature — Used in `#[cfg(test)]` modules
+- `duckdb = "=1.10503.1"` with `bundled` feature — Used in `#[cfg(test)]` modules
   for `Connection::open_in_memory()`. Not linked into the release extension.
-  Note: crate versioning uses `1.MAJOR_MINOR_PATCH.x` scheme (DuckDB v1.5.2 →
-  crate v1.10502.x).
+  Note: crate versioning uses `1.MAJOR_MINOR_PATCH.x` scheme (DuckDB v1.5.3 →
+  crate v1.10503.x).
 - `criterion = "0.8"` with `html_reports` feature — Statistical benchmarking
 - `proptest = "1"` — Property-based testing
 
@@ -198,7 +198,7 @@ Every change MUST meet these requirements:
   ClickHouse mode combinations, and `AggregateTestHarness` combine
   config-propagation tests for all 5 aggregate functions
 - **1 doc-test** for the pattern parser
-- **E2E tests** against real DuckDB v1.5.2 CLI: 11 workflow test steps
+- **E2E tests** against real DuckDB v1.5.3 CLI: 11 workflow test steps
   (2 platforms) plus 7 SQL integration test files with 59 queries covering
   all 7 functions with multiple scenarios (basic, timeout, modes, GROUP BY,
   no-match, NULL inputs, empty tables, all funnel modes, 5+ conditions,
@@ -208,9 +208,10 @@ Every change MUST meet these requirements:
   cardinality benchmarks, and throughput reporting up to 1B elements
 - **Mutation testing**: 88.4% kill rate baseline via cargo-mutants
   (130 caught / 17 missed) measured on the v0.4.x codebase. cargo-mutants
-  27.0.0 now identifies ~465 candidate mutations on the v0.5.0 source —
-  a re-measurement is tracked as a separate session
-- **MSRV 1.86** verified in CI (raised from 1.84.1; required by `libduckdb-sys`/`duckdb` 1.85.1 and `criterion` 0.8.2 1.86)
+  27.0.0 now identifies ~465 candidate mutations on the v0.6.0 source
+  (unchanged from v0.5.0) — a re-measurement is tracked as a separate session
+- **MSRV 1.87** verified in CI (raised from 1.86; required by `quack-rs` v0.13.0,
+  whose corrected MSRV aligns with `libduckdb-sys`)
 - All public items have documentation
 - Release profile: LTO, single codegen unit, abort on panic, stripped symbols
 
@@ -402,7 +403,7 @@ Hard-won knowledge from developing this extension. Consult before making changes
 
 - **Extension metadata version uses DuckDB release version**: The
   `append_extension_metadata.py -dv` flag takes the DuckDB release version
-  (e.g., `v1.5.2`). The community extension Makefile sets this automatically
+  (e.g., `v1.5.3`). The community extension Makefile sets this automatically
   from `TARGET_DUCKDB_VERSION`. The ABI type is `C_STRUCT_UNSTABLE`.
 
 - **`sessionize` cannot use quack-rs**: DuckDB's public C Extension API does not

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,9 +22,9 @@ cargo fmt -- --check           # Format check
 
 ## Development Requirements
 
-- Rust 1.86+ (the project's MSRV)
+- Rust 1.87+ (the project's MSRV)
 - A C compiler (for DuckDB system bindings)
-- DuckDB CLI v1.5.2 (for E2E testing)
+- DuckDB CLI v1.5.3 (for E2E testing)
 
 ## Key Principles
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -625,9 +625,9 @@ dependencies = [
 
 [[package]]
 name = "duckdb"
-version = "1.10502.0"
+version = "1.10503.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fdc796383b176dd5a45353fbb5e64583c0ee4da12cb62c9e510b785324b2488"
+checksum = "0cb42b21e3be42ef14acda15ce8dc99c125ce5376b87c8016a432cf14ae65de1"
 dependencies = [
  "arrow",
  "cast",
@@ -643,7 +643,7 @@ dependencies = [
 
 [[package]]
 name = "duckdb-behavioral"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "criterion",
  "duckdb",
@@ -1260,9 +1260,9 @@ checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libduckdb-sys"
-version = "1.10502.0"
+version = "1.10503.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d7401630ae2abcff642f7156294289e50f2d222e061c026ad797b01bf20c215"
+checksum = "c9a4389c243e7afa0fbc8d8471031335ddc8a2dac4534f3290c9c2ba3edabab5"
 dependencies = [
  "cc",
  "flate2",
@@ -1590,9 +1590,9 @@ dependencies = [
 
 [[package]]
 name = "quack-rs"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5145ffbe329e3b0c07cf487db3704c5a357da27b3be4f37e1c12abe7e3eb144c"
+checksum = "cfce2bec24a1d312ce8e5a8e0accfc06331360c33ba11edb7d455f1e975e1bdc"
 dependencies = [
  "cc",
  "libduckdb-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,9 +3,9 @@
 
 [package]
 name = "duckdb-behavioral"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
-rust-version = "1.86"
+rust-version = "1.87"
 authors = ["Tom F <tomtom215@users.noreply.github.com>"]
 description = "Behavioral analytics functions for DuckDB: sessionize, retention, funnels, sequence matching"
 license = "MIT"
@@ -20,11 +20,11 @@ name = "behavioral"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-quack-rs = "0.12.0"
-libduckdb-sys = { version = "=1.10502.0", features = ["loadable-extension"] }
+quack-rs = "=0.13.0"
+libduckdb-sys = { version = "=1.10503.1", features = ["loadable-extension"] }
 
 [dev-dependencies]
-duckdb = { version = "=1.10502.0", features = ["bundled"] }
+duckdb = { version = "=1.10503.1", features = ["bundled"] }
 criterion = { version = "0.8", features = ["html_reports"] }
 proptest = "1"
 

--- a/Makefile
+++ b/Makefile
@@ -10,11 +10,11 @@ EXTENSION_NAME=behavioral
 # Required: duckdb-rs relies on unstable C API functionality
 USE_UNSTABLE_C_API=1
 
-# Target DuckDB version (must match duckdb = "=1.10502.0" pin in Cargo.toml)
-TARGET_DUCKDB_VERSION=v1.5.2
+# Target DuckDB version (must match duckdb = "=1.10503.1" pin in Cargo.toml)
+TARGET_DUCKDB_VERSION=v1.5.3
 
 # Pin the test runner to the same DuckDB version (extension-ci-tools defaults to latest)
-DUCKDB_TEST_VERSION=1.5.2
+DUCKDB_TEST_VERSION=1.5.3
 
 all: configure debug
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
   <a href="https://github.com/tomtom215/duckdb-behavioral/actions/workflows/e2e.yml"><img src="https://github.com/tomtom215/duckdb-behavioral/actions/workflows/e2e.yml/badge.svg" alt="E2E Tests"></a>
   <a href="https://crates.io/crates/duckdb-behavioral"><img src="https://img.shields.io/crates/v/duckdb-behavioral.svg" alt="Crates.io"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-blue.svg" alt="License: MIT"></a>
-  <a href="https://www.rust-lang.org"><img src="https://img.shields.io/badge/MSRV-1.86-blue.svg" alt="MSRV: 1.86"></a>
+  <a href="https://www.rust-lang.org"><img src="https://img.shields.io/badge/MSRV-1.87-blue.svg" alt="MSRV: 1.87"></a>
   <a href="https://tomtom215.github.io/duckdb-behavioral/"><img src="https://img.shields.io/badge/docs-mdBook-blue.svg" alt="Documentation"></a>
 </p>
 
@@ -414,7 +414,7 @@ E2E tests against real DuckDB, CodeQL static analysis, SemVer validation, and
 
 ## Building
 
-**Prerequisites**: Rust 1.86+ (MSRV), a C compiler (for DuckDB sys bindings)
+**Prerequisites**: Rust 1.87+ (MSRV), a C compiler (for DuckDB sys bindings)
 
 ```bash
 # Build the extension (release mode)
@@ -460,8 +460,8 @@ for the full SemVer rules applied to SQL function signatures.
 
 ## Requirements
 
-- Rust 1.86+ (MSRV)
-- DuckDB 1.5.1 (pinned dependency)
+- Rust 1.87+ (MSRV)
+- DuckDB 1.5.3 (pinned dependency)
 - Python 3.x (for extension metadata tooling)
 
 ## License

--- a/README.md
+++ b/README.md
@@ -389,7 +389,7 @@ version, update `libduckdb-sys`, `TARGET_DUCKDB_VERSION`, and the
 | Property-based tests | 29 (proptest) |
 | Mutation testing | 88.4% kill rate (130/147, cargo-mutants) |
 | Clippy warnings | 0 (pedantic + nursery + cargo lint groups) |
-| CI jobs | 13 (check, test, clippy, fmt, doc, MSRV, bench, deny, semver, coverage, cross-platform, extension-build) |
+| CI jobs | 13 (check, test, clippy, fmt, doc, MSRV, bench-compile, deny, semver, coverage, cross-platform, extension-build, ci-gate) |
 | Benchmark files | 7 (Criterion.rs, up to 1 billion elements) |
 | Release platforms | 4 (Linux x86_64/ARM64, macOS x86_64/ARM64) |
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -31,8 +31,8 @@ safe Rust. Every `unsafe` block has a `// SAFETY:` documentation comment.
 
 ### Dependency Audit
 
-The extension has exactly **two** runtime dependencies (`quack-rs = "0.12.0"`
-and `libduckdb-sys = "=1.10502.0"`, both pinned exactly). All dependencies are
+The extension has exactly **two** runtime dependencies (`quack-rs = "=0.13.0"`
+and `libduckdb-sys = "=1.10503.1"`, both pinned exactly). All dependencies are
 audited via `cargo-deny` in CI for known advisories and license compliance.
 
 ### Build Integrity

--- a/description.yml
+++ b/description.yml
@@ -4,7 +4,7 @@
 extension:
   name: behavioral
   description: Behavioral analytics functions inspired by ClickHouse (sessionize, retention, window_funnel, sequence_match, sequence_count, sequence_match_events, sequence_next_node)
-  version: 0.5.0
+  version: 0.6.0
   language: Rust
   build: cargo
   license: MIT

--- a/docs/src/contributing.md
+++ b/docs/src/contributing.md
@@ -6,9 +6,9 @@ Guidelines for contributing to `duckdb-behavioral`.
 
 ### Prerequisites
 
-- Rust 1.86+ (the project's MSRV)
+- Rust 1.87+ (the project's MSRV)
 - A C compiler (for DuckDB system bindings)
-- DuckDB CLI v1.5.2 (for E2E testing)
+- DuckDB CLI v1.5.3 (for E2E testing)
 
 ### Building
 
@@ -46,7 +46,7 @@ configuration and allowed exceptions (FFI callbacks, analytics math casts).
 - **Pure Rust core**: Business logic in top-level modules (`sessionize.rs`,
   `retention.rs`, etc.) with zero FFI dependencies.
 - **FFI bridge via quack-rs SDK**: DuckDB C API registration confined to
-  `src/ffi/`, using [quack-rs](https://crates.io/crates/quack-rs) v0.12.0
+  `src/ffi/`, using [quack-rs](https://crates.io/crates/quack-rs) v0.13.0
   for safe builders (including `returns_logical(LogicalType)` for
   `LIST(T)` returns), state management (`FfiState<T>`), vector I/O
   (`VectorReader`/`VectorWriter`), LIST output (`ListVector`), and type
@@ -102,7 +102,7 @@ cargo build --release
 cp target/release/libbehavioral.so /tmp/behavioral.duckdb_extension
 python3 extension-ci-tools/scripts/append_extension_metadata.py \
   -l /tmp/behavioral.duckdb_extension -n behavioral \
-  -p linux_amd64 -dv v1.2.0 -ev v0.2.0 --abi-type C_STRUCT \
+  -p linux_amd64 -dv v1.5.3 -ev v0.6.0 --abi-type C_STRUCT_UNSTABLE \
   -o /tmp/behavioral.duckdb_extension
 
 # Load and test

--- a/docs/src/engineering.md
+++ b/docs/src/engineering.md
@@ -415,7 +415,7 @@ incorrect results that passed all unit tests but failed E2E validation.
 | MSRV | Rust 1.87 |
 | Criterion benchmark files | 7 |
 | Max benchmark scale | 1 billion elements |
-| CI jobs | 13 (check, test, clippy, fmt, doc, MSRV, bench, deny, semver, coverage, cross-platform, extension-build) |
+| CI jobs | 13 (check, test, clippy, fmt, doc, MSRV, bench-compile, deny, semver, coverage, cross-platform, extension-build, ci-gate) |
 | Documented negative results | 5 (radix sort, branchless, string pool, compiled pattern, first-condition pre-check) |
 | ClickHouse parity | Complete (7/7 functions, all modes, 32 conditions) |
 

--- a/docs/src/engineering.md
+++ b/docs/src/engineering.md
@@ -311,7 +311,7 @@ these analyses can run as interactive queries rather than batch jobs.
 
 DuckDB's Rust crate does not provide high-level aggregate function
 registration. This project uses the [quack-rs](https://crates.io/crates/quack-rs)
-SDK (v0.12.0) which wraps the raw C API with safe builders
+SDK (v0.13.0) which wraps the raw C API with safe builders
 (including `returns_logical(LogicalType)` for `LIST(T)` return types),
 state management, vector I/O, and LIST output helpers. All 6 aggregate
 functions use the builder for registration. The `sessionize` function
@@ -412,7 +412,7 @@ incorrect results that passed all unit tests but failed E2E validation.
 | Mutation kill rate | 88.4% (130/147) |
 | Clippy warnings | 0 (pedantic + nursery + cargo) |
 | Unsafe block count | Confined to `src/ffi/` (6 files) |
-| MSRV | Rust 1.86 |
+| MSRV | Rust 1.87 |
 | Criterion benchmark files | 7 |
 | Max benchmark scale | 1 billion elements |
 | CI jobs | 13 (check, test, clippy, fmt, doc, MSRV, bench, deny, semver, coverage, cross-platform, extension-build) |
@@ -425,8 +425,8 @@ incorrect results that passed all unit tests but failed E2E validation.
 
 | Layer | Technology | Purpose |
 |---|---|---|
-| Language | Rust (stable, MSRV 1.86) | Memory safety, zero-cost abstractions, `unsafe` confinement |
-| Database | DuckDB 1.5.1 | Analytical SQL engine, segment tree windowing |
+| Language | Rust (stable, MSRV 1.87) | Memory safety, zero-cost abstractions, `unsafe` confinement |
+| Database | DuckDB 1.5.3 | Analytical SQL engine, segment tree windowing |
 | FFI | libduckdb-sys (C API) | Raw aggregate function registration |
 | Benchmarking | Criterion.rs | Statistical benchmarking with confidence intervals |
 | Property testing | proptest | Algebraic property verification |

--- a/docs/src/faq.md
+++ b/docs/src/faq.md
@@ -42,9 +42,10 @@ duckdb -unsigned -c "LOAD 'target/release/libbehavioral.so'; SELECT ..."
 ### The extension fails to load. What should I check?
 
 1. **DuckDB version mismatch**: The community extension is built for DuckDB
-   v1.5.2. If you are using a different DuckDB version, the extension may not
-   be available for that version yet. For locally-built extensions, the C API
-   version must match (currently `v1.2.0`).
+   v1.5.3. If you are using a different DuckDB version, the extension may not
+   be available for that version yet. For locally-built extensions, the DuckDB
+   release version stamped into the extension metadata (the `-dv` flag) must
+   match the loading CLI exactly (currently `v1.5.3`).
 
 2. **Missing `-unsigned` flag** (local builds only): DuckDB rejects unsigned
    extensions by default. Use `duckdb -unsigned` or set

--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -29,9 +29,9 @@ platform where Rust and DuckDB are available.
 
 **Prerequisites:**
 
-- Rust 1.86 or later (`rustup` recommended)
+- Rust 1.87 or later (`rustup` recommended)
 - A C compiler (gcc, clang, or MSVC -- needed for DuckDB system bindings)
-- DuckDB CLI v1.5.2 (for running queries)
+- DuckDB CLI v1.5.3 (for running queries)
 
 **Build steps:**
 
@@ -64,7 +64,7 @@ cp target/release/libbehavioral.so /tmp/behavioral.duckdb_extension
 # Append extension metadata
 python3 extension-ci-tools/scripts/append_extension_metadata.py \
   -l /tmp/behavioral.duckdb_extension -n behavioral \
-  -p linux_amd64 -dv v1.2.0 -ev v0.2.0 --abi-type C_STRUCT \
+  -p linux_amd64 -dv v1.5.3 -ev v0.6.0 --abi-type C_STRUCT_UNSTABLE \
   -o /tmp/behavioral.duckdb_extension
 ```
 
@@ -288,15 +288,15 @@ matched Home -> Product sequence.
 
 **"file was built for DuckDB C API version '...' but we can only load extensions built for DuckDB C API '...'"**
 
-The extension is built against DuckDB C API version `v1.2.0` (used by DuckDB
-v1.5.2). You must use a DuckDB CLI version that matches. Check your version
+The extension is stamped with the DuckDB release version it was built against
+(`v1.5.3`). You must use a DuckDB CLI version that matches. Check your version
 with:
 
 ```bash
 duckdb --version
 ```
 
-If you see a different version, either install DuckDB v1.5.2 or rebuild the
+If you see a different version, either install DuckDB v1.5.3 or rebuild the
 extension against your DuckDB version (this requires updating the
 `libduckdb-sys` dependency in `Cargo.toml`).
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -7,7 +7,7 @@
 <a href="https://github.com/tomtom215/duckdb-behavioral/actions/workflows/ci.yml"><img src="https://github.com/tomtom215/duckdb-behavioral/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
 <a href="https://github.com/tomtom215/duckdb-behavioral/actions/workflows/e2e.yml"><img src="https://github.com/tomtom215/duckdb-behavioral/actions/workflows/e2e.yml/badge.svg" alt="E2E Tests"></a>
 <a href="https://github.com/tomtom215/duckdb-behavioral/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-MIT-blue.svg" alt="License: MIT"></a>
-<a href="https://www.rust-lang.org"><img src="https://img.shields.io/badge/MSRV-1.86-blue.svg" alt="MSRV: 1.86"></a>
+<a href="https://www.rust-lang.org"><img src="https://img.shields.io/badge/MSRV-1.87-blue.svg" alt="MSRV: 1.87"></a>
 </div>
 
 # duckdb-behavioral
@@ -274,8 +274,8 @@ For a comprehensive technical overview, see the
 
 ## Requirements
 
-- **DuckDB 1.5.1** (C API version v1.2.0)
-- **Rust 1.86+** (MSRV) for building from source
+- **DuckDB 1.5.3**
+- **Rust 1.87+** (MSRV) for building from source
 - A C compiler for DuckDB system bindings
 
 ## Source Code

--- a/docs/src/internals/architecture.md
+++ b/docs/src/internals/architecture.md
@@ -85,7 +85,7 @@ hand-rolled unsafe code from earlier versions.
 
 ### quack-rs SDK
 
-The FFI layer uses [quack-rs](https://crates.io/crates/quack-rs) v0.12.0,
+The FFI layer uses [quack-rs](https://crates.io/crates/quack-rs) v0.13.0,
 a Rust SDK for DuckDB loadable extensions. It provides:
 
 - **`AggregateFunctionSetBuilder`**: Safe registration of function sets with

--- a/docs/src/internals/performance.md
+++ b/docs/src/internals/performance.md
@@ -187,7 +187,7 @@ Discovered and fixed 3 critical bugs that all 375 passing unit tests at the time
    time.
 
 No performance optimization targets. 11 E2E tests added against real DuckDB
-v1.5.2 CLI.
+v1.5.3 CLI.
 
 ### NFA Fast Paths
 

--- a/docs/src/operations/ci-cd.md
+++ b/docs/src/operations/ci-cd.md
@@ -17,7 +17,7 @@ ensure code quality across multiple dimensions.
 | **clippy** | Zero-warning lint enforcement | `cargo clippy` with `-D warnings` |
 | **fmt** | Formatting verification | `cargo fmt --check` |
 | **doc** | Documentation builds without warnings | `cargo doc` with `-Dwarnings` |
-| **msrv** | Minimum Supported Rust Version (1.86) | `cargo check` with pinned toolchain |
+| **msrv** | Minimum Supported Rust Version (1.87) | `cargo check` with pinned toolchain |
 | **bench-compile** | Benchmarks compile (no execution) | `cargo bench --no-run` |
 | **deny** | License, advisory, and source auditing | `cargo-deny` |
 | **semver** | Semver compatibility check | `cargo-semver-checks` |

--- a/docs/src/operations/security.md
+++ b/docs/src/operations/security.md
@@ -54,7 +54,6 @@ release extension binary:
 | `duckdb` | In-memory connection for unit tests |
 | `criterion` | Benchmarking framework |
 | `proptest` | Property-based testing |
-| `rand` | Random data generation for benchmarks |
 
 ### License Compliance
 
@@ -89,7 +88,7 @@ to pin all transitive dependency versions.
 Release artifacts include:
 
 1. **SHA256 checksums** (`SHA256SUMS.txt`) for every release artifact
-2. **GitHub artifact attestations** via `actions/attest-build-provenance@v3`,
+2. **GitHub artifact attestations** via `actions/attest-build-provenance@v4`,
    which provides a cryptographic link between the artifact and the GitHub
    Actions build that produced it
 3. **Immutable build logs** in GitHub Actions with full command output
@@ -101,7 +100,7 @@ Release artifacts include:
 sha256sum -c SHA256SUMS.txt
 
 # Verify GitHub attestation (requires gh CLI)
-gh attestation verify behavioral-v0.2.0-linux_amd64.tar.gz \
+gh attestation verify behavioral-v0.6.0-linux_amd64.tar.gz \
   --repo tomtom215/duckdb-behavioral
 ```
 

--- a/docs/src/operations/security.md
+++ b/docs/src/operations/security.md
@@ -34,8 +34,8 @@ The extension has exactly **two** runtime dependencies:
 
 | Crate | Version | Purpose |
 |-------|---------|---------|
-| `quack-rs` | `=0.12.0` | Rust SDK for DuckDB loadable extensions — entry point macro, aggregate builders, safe state management, vector I/O |
-| `libduckdb-sys` | `=1.10502.0` | DuckDB C API bindings (re-exported by quack-rs; kept explicitly for `sessionize` window function FFI) |
+| `quack-rs` | `=0.13.0` | Rust SDK for DuckDB loadable extensions — entry point macro, aggregate builders, safe state management, vector I/O |
+| `libduckdb-sys` | `=1.10503.1` | DuckDB C API bindings (re-exported by quack-rs; kept explicitly for `sessionize` window function FFI) |
 
 Both versions are **pinned exactly** to prevent silent dependency updates.
 `quack-rs` provides `entry_point_v2!`, `Connection`/`Registrar` trait,

--- a/docs/src/quick-reference.md
+++ b/docs/src/quick-reference.md
@@ -103,7 +103,7 @@ sequence_next_node('direction', 'base', timestamp_col, value_col,
 
 **Directions:** `'forward'`, `'backward'`
 
-**Bases:** `'head'` (alias: `'first_match'`), `'tail'` (alias: `'last_match'`)
+**Bases:** `'head'`, `'tail'` (first/last `base_condition` event), `'first_match'`, `'last_match'` (first/last complete match) — four distinct strategies, 8 direction × base combinations
 
 ---
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -33,10 +33,10 @@ set -euo pipefail
 # version of the DuckDB CLI loading the extension (DuckDB compares this
 # field exactly and refuses to load on a mismatch). Mirrors the Makefile's
 # TARGET_DUCKDB_VERSION used by the official `make release` build.
-readonly DUCKDB_RELEASE_VERSION="v1.5.2"
+readonly DUCKDB_RELEASE_VERSION="v1.5.3"
 
 # Extension version from Cargo.toml
-readonly EXT_VERSION="v0.5.0"
+readonly EXT_VERSION="v0.6.0"
 
 # Extension name
 readonly EXT_NAME="behavioral"
@@ -107,22 +107,23 @@ find_duckdb() {
 }
 
 install_duckdb() {
-    log_info "DuckDB CLI not found. Installing v1.5.2..."
+    log_info "DuckDB CLI not found. Installing ${DUCKDB_RELEASE_VERSION}..."
 
     local os
     local arch
     os="$(uname -s | tr '[:upper:]' '[:lower:]')"
     arch="$(uname -m)"
 
+    local base="https://github.com/duckdb/duckdb/releases/download/${DUCKDB_RELEASE_VERSION}"
     local url=""
     if [[ "${os}" == "linux" && "${arch}" == "x86_64" ]]; then
-        url="https://github.com/duckdb/duckdb/releases/download/v1.5.2/duckdb_cli-linux-amd64.zip"
+        url="${base}/duckdb_cli-linux-amd64.zip"
     elif [[ "${os}" == "linux" && "${arch}" == "aarch64" ]]; then
-        url="https://github.com/duckdb/duckdb/releases/download/v1.5.2/duckdb_cli-linux-aarch64.zip"
+        url="${base}/duckdb_cli-linux-aarch64.zip"
     elif [[ "${os}" == "darwin" && "${arch}" == "x86_64" ]]; then
-        url="https://github.com/duckdb/duckdb/releases/download/v1.5.2/duckdb_cli-osx-universal.zip"
+        url="${base}/duckdb_cli-osx-universal.zip"
     elif [[ "${os}" == "darwin" && "${arch}" == "arm64" ]]; then
-        url="https://github.com/duckdb/duckdb/releases/download/v1.5.2/duckdb_cli-osx-universal.zip"
+        url="${base}/duckdb_cli-osx-universal.zip"
     else
         log_err "Unsupported platform: ${os}/${arch}"
         return 1

--- a/src/ffi/mod.rs
+++ b/src/ffi/mod.rs
@@ -5,7 +5,7 @@
 //!
 //! # Architecture
 //!
-//! All modules except [`sessionize`] use the `quack-rs` v0.12 SDK for
+//! All modules except [`sessionize`] use the `quack-rs` v0.13 SDK for
 //! registration, state management, and vector I/O:
 //!
 //! - [`quack_rs::aggregate::AggregateFunctionSetBuilder`] — registers function


### PR DESCRIPTION
## Summary

Modernizes the extension to the current DuckDB release line, which is what restores its **DuckDB Community Extensions** listing — the registry had de-listed it for targeting the older v1.5.2.

- **DuckDB v1.5.2 → v1.5.3**: `libduckdb-sys` / `duckdb` (dev) `1.10502.0` → `1.10503.1`
- **quack-rs 0.12.0 → 0.13.0**, now exact-pinned to match the documented runtime-dependency policy. Compiles with **zero source changes** — every aggregate-registration API is unchanged in 0.13.0.
- **MSRV 1.86 → 1.87** (quack-rs 0.13.0 corrected its declared MSRV to match `libduckdb-sys`)
- **Version bump 0.5.0 → 0.6.0** (Cargo.toml + description.yml kept consistent, as the submission workflow validates)

## Engineering quality (defects found & fixed while auditing)

- Broken metadata-append examples (`-dv v1.2.0 ... --abi-type C_STRUCT`) that produce extensions DuckDB 1.5.x **rejects on load** → corrected to `-dv v1.5.3 ... --abi-type C_STRUCT_UNSTABLE`
- DRY-ed `scripts/setup.sh` so DuckDB CLI URLs derive from one constant (closing the duplication that caused the version drift)
- Full doc accuracy pass: fixed "13 CI jobs" lists (missing `ci-gate`), a false `sequence_next_node` base-alias claim, a spurious `rand` dev-dependency, `attest-build-provenance@v3` → `@v4`, and stale "DuckDB 1.5.1 / C API v1.2.0" references

## Verification

- `cargo test`: **453 unit tests + 1 doc-test pass**; `clippy --all-targets` (and `-D warnings`); `fmt --check`; `doc -D warnings` — all clean
- Cargo.lock shows **zero transitive churn** (only the 3 target crates changed)
- **Real E2E**: built the release `.so`, stamped v1.5.3 metadata, loaded into the actual **DuckDB v1.5.3 CLI** — all 7 functions registered and returned correct results (the check that catches FFI bugs unit tests can't)
- Doc consistency sweep clean; all 21 mdBook pages + internal links verified

## Test plan

- [ ] CI green (check, test, clippy, fmt, doc, MSRV 1.87, deny, semver, coverage, cross-platform, extension-build, ci-gate)
- [ ] E2E workflow passes on Linux + macOS against DuckDB v1.5.3
- [ ] Post-merge: tag `v0.6.0` → run `community-submission.yml` (pins `description.yml` ref) → open PR to `duckdb/community-extensions`

https://claude.ai/code/session_01PdfGvXBMrEbLD7wecaWrSt

---
_Generated by [Claude Code](https://claude.ai/code/session_01PdfGvXBMrEbLD7wecaWrSt)_