### PR TITLE
Update quack-rs to v0.14.0, add in-process integration tests, bump to v0.7.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -29,7 +29,7 @@ What actually happened. Include any error messages.
 ## Environment
 
 - **DuckDB version**: (e.g., v1.5.3)
-- **Extension version**: (e.g., v0.6.0 or built from source)
+- **Extension version**: (e.g., v0.7.0 or built from source)
 - **OS**: (e.g., Ubuntu 24.04, macOS 15, Windows 11)
 - **Architecture**: (e.g., x86_64, aarch64)
 - **Loaded with**: `-unsigned` flag / community extension

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,7 +18,7 @@ Brief description of what this PR does and why.
 
 ## Testing
 
-- [ ] `cargo test` passes (453 unit tests + 1 doc-test)
+- [ ] `cargo test` passes (453 unit + 7 integration + 1 doc-test)
 - [ ] `cargo clippy --all-targets` produces zero warnings
 - [ ] `cargo fmt -- --check` passes
 - [ ] `cargo doc --no-deps` builds without warnings

--- a/.github/workflows/community-submission.yml
+++ b/.github/workflows/community-submission.yml
@@ -459,6 +459,7 @@ jobs:
           ### Testing
 
           - 453 unit tests + 1 doc-test (29 proptest)
+          - 7 in-process integration tests (real extension load via InMemoryDb)
           - 11 E2E workflow test steps per platform against real DuckDB v1.5.3
           - 7 SQL integration test files (59 queries) in test/sql/
           - Criterion.rs benchmarks up to 1 billion elements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,58 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-06-07
+
+### Changed
+
+- **quack-rs v0.14.0** — upgraded from v0.13.0. Every public API this crate uses
+  (`AggregateFunctionSetBuilder`, `FfiState`, `VectorReader`/`VectorWriter`,
+  `ListVector`, `LogicalType::list`, `returns_logical`, `AggregateTestHarness`,
+  `Connection`/`Registrar`, `entry_point_v2!`) is unchanged: the extension
+  compiles against the new SDK with **zero changes to existing source**. v0.14.0
+  is purely additive — it adds `wasm32-unknown-emscripten` (DuckDB-WASM) support,
+  a `bundled-test-prebuilt` test feature, and `InMemoryDb::open_unsigned()`. MSRV
+  stays 1.87; DuckDB stays v1.5.3 (`libduckdb-sys`/`duckdb` `1.10503.1`, already
+  the latest).
+
+### Added
+
+- **In-process extension-load integration test** (`tests/extension_load.rs`, 7
+  tests). Builds the real release `cdylib`, appends the DuckDB metadata footer
+  (a Rust port of `append_extension_metadata.py`), and `LOAD`s it into an
+  in-memory DuckDB via quack-rs 0.14.0's
+  `testing::InMemoryDb::open_unsigned()`, then exercises **all seven functions**
+  through live SQL. This runs inside `cargo test` with no external `duckdb` CLI
+  and closes the long-standing gap where unit tests could pass while the FFI
+  registration path was broken (the segfault-on-load / silent-non-registration /
+  wrong-result class of bugs). Adds the `quack-rs` `bundled-test` dev-feature,
+  which unifies with the existing `duckdb/bundled` dev-dependency — no extra
+  DuckDB build.
+
+### Security
+
+- **Dependency refresh via `cargo update`** — notably `tar` 0.4.45 → 0.4.46
+  (resolves **GHSA-3pv8-6f4r-ffg2**, "PAX header desynchronization"; `tar` is a
+  build-time dependency of `libduckdb-sys`), plus `cc` 1.2.61 → 1.2.63 and
+  `shlex` 1.3.0 → 2.0.1, and routine bumps across the dev/transitive tree
+  (`arrow` 58.1 → 58.3, `tokio`, `wasm-bindgen`, `zerocopy`, …). All direct
+  dependencies are at their latest versions; the sole held-back transitive crate
+  is `comfy-table` (constrained by the `duckdb` dev-dependency). All bumped
+  crates declare an MSRV ≤ 1.85, so the project MSRV stays 1.87.
+- **`deny.toml`** — added a tightly-scoped `CC0-1.0` license exception for
+  `tiny-keccak`, a phantom `Cargo.lock` entry behind `ahash`'s optional,
+  never-enabled `compile-time-rng` feature (absent from every buildable graph and
+  from the shipped `.so`). This lets current `cargo-deny` releases pass the
+  license gate, future-proofing CI against the pinned action updating.
+
+### Documentation
+
+- Updated every version reference to the `v0.7.0` / quack-rs `v0.14.0` baseline
+  (DuckDB `v1.5.3` and MSRV `1.87` unchanged) across `README.md`, `CLAUDE.md`,
+  `SECURITY.md`, `description.yml`, `scripts/setup.sh`, `docs/src/**.md`, the
+  issue/PR templates, and the community-submission workflow, and documented the
+  new in-process integration-test layer.
+
 ## [0.6.0] - 2026-05-24
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,7 +59,7 @@ src/
    submodules handle DuckDB C API registration only.
 
 2. **Aggregate functions via quack-rs SDK**: DuckDB's Rust crate does not yet
-   provide high-level aggregate function registration. We use `quack-rs` v0.13.0
+   provide high-level aggregate function registration. We use `quack-rs` v0.14.0
    ([crates.io](https://crates.io/crates/quack-rs)) which wraps the raw C API with safe builders
    (`AggregateFunctionSetBuilder`), state management (`FfiState<T>`), vector I/O
    (`VectorReader`/`VectorWriter` including `write_varchar`), complex type helpers
@@ -69,6 +69,8 @@ src/
    including `retention` and `sequence_match_events` which use
    `returns_logical(LogicalType::list(...))` for their `LIST(T)` return types.
    `sessionize` remains fully hand-rolled (window function limitation in quack-rs).
+   The `bundled-test` dev-feature additionally provides `testing::InMemoryDb`,
+   used by the in-process extension-load integration test (see [Testing](#testing)).
 
 3. **Function sets for variadic signatures**: Since `duckdb_aggregate_function_set_varargs`
    doesn't exist, we register function sets with 31 overloads (2-32 boolean parameters)
@@ -111,7 +113,7 @@ cargo build
 # Build from source (release, produces loadable .so/.dylib)
 cargo build --release
 
-# Run all unit tests (453 tests + 1 doc-test)
+# Run all tests (453 unit + 7 integration + 1 doc-test)
 cargo test
 
 # Run clippy (must produce zero warnings)
@@ -133,7 +135,7 @@ cargo build --release
 cp target/release/libbehavioral.so /tmp/behavioral.duckdb_extension
 python3 extension-ci-tools/scripts/append_extension_metadata.py \
   -l /tmp/behavioral.duckdb_extension -n behavioral \
-  -p linux_amd64 -dv v1.5.3 -ev v0.6.0 --abi-type C_STRUCT_UNSTABLE \
+  -p linux_amd64 -dv v1.5.3 -ev v0.7.0 --abi-type C_STRUCT_UNSTABLE \
   -o /tmp/behavioral.duckdb_extension
 # 3. Load and test
 duckdb -unsigned -c "LOAD '/tmp/behavioral.duckdb_extension'; SELECT ..."
@@ -154,7 +156,7 @@ duckdb -unsigned -c "LOAD '/tmp/behavioral.duckdb_extension'; SELECT ..."
 ## Dependencies
 
 **Runtime** (linked into the `.so`/`.dylib`):
-- `quack-rs` v0.13.0 ([crates.io](https://crates.io/crates/quack-rs)) — Rust SDK
+- `quack-rs` v0.14.0 ([crates.io](https://crates.io/crates/quack-rs)) — Rust SDK
   for DuckDB loadable extensions. Provides `entry_point_v2!` macro,
   `Connection`/`Registrar` trait for version-agnostic registration,
   `AggregateFunctionSetBuilder` (with `returns_logical(LogicalType)` for `LIST(T)` returns),
@@ -173,6 +175,11 @@ duckdb -unsigned -c "LOAD '/tmp/behavioral.duckdb_extension'; SELECT ..."
   for `Connection::open_in_memory()`. Not linked into the release extension.
   Note: crate versioning uses `1.MAJOR_MINOR_PATCH.x` scheme (DuckDB v1.5.3 →
   crate v1.10503.x).
+- `quack-rs` v0.14.0 with `bundled-test` feature — Provides `testing::InMemoryDb`
+  (incl. `open_unsigned()`) for the in-process extension-load integration test
+  (`tests/extension_load.rs`). Its `duckdb/bundled` requirement unifies with the
+  `duckdb` dev-dependency above (no extra DuckDB build); dev-only, never in the
+  release `.so`.
 - `criterion = "0.8"` with `html_reports` feature — Statistical benchmarking
 - `proptest = "1"` — Property-based testing
 
@@ -199,6 +206,11 @@ Every change MUST meet these requirements:
   config-propagation tests for all 6 aggregate functions (across 5 FFI test
   modules -- `sequence_match` and `sequence_count` share one state type)
 - **1 doc-test** for the pattern parser
+- **7 in-process integration tests** (`tests/extension_load.rs`): build the real
+  release `cdylib`, append the DuckDB metadata footer, `LOAD` it into an
+  in-memory DuckDB via `quack_rs::testing::InMemoryDb::open_unsigned()`, and
+  exercise all 7 functions through live SQL — the registration/FFI path unit
+  tests cannot reach, now covered inside `cargo test` (no external CLI)
 - **E2E tests** against real DuckDB v1.5.3 CLI: 11 workflow test steps
   (2 platforms) plus 7 SQL integration test files with 59 queries covering
   all 7 functions with multiple scenarios (basic, timeout, modes, GROUP BY,
@@ -209,10 +221,10 @@ Every change MUST meet these requirements:
   cardinality benchmarks, and throughput reporting up to 1B elements
 - **Mutation testing**: 88.4% kill rate baseline via cargo-mutants
   (130 caught / 17 missed) measured on the v0.4.x codebase. cargo-mutants
-  27.0.0 now identifies ~465 candidate mutations on the v0.6.0 source
+  27.0.0 now identifies ~465 candidate mutations on the v0.7.0 source
   (unchanged from v0.5.0) — a re-measurement is tracked as a separate session
-- **MSRV 1.87** verified in CI (raised from 1.86; required by `quack-rs` v0.13.0,
-  whose corrected MSRV aligns with `libduckdb-sys`)
+- **MSRV 1.87** verified in CI (raised from 1.86 at `quack-rs` v0.13.0;
+  v0.14.0 keeps the declared MSRV of 1.87.0, which aligns with `libduckdb-sys`)
 - All public items have documentation
 - Release profile: LTO, single codegen unit, abort on panic, stripped symbols
 
@@ -309,7 +321,18 @@ Tests are organized as `#[cfg(test)] mod tests` within each module.
 - **`sequence_next_node` tests**: All 8 direction/base combinations,
   multi-step patterns, combine, NULL handling, Arc\<str\> sharing
 
-Run with `cargo test`. All 453 tests + 1 doc-test run in <1 second.
+Run with `cargo test`. The 453 unit tests run in <1 second (the doc-test in
+~2s). The 7 in-process integration tests add ~15s on a cold run — they build and
+`LOAD` the real release `cdylib` — and are near-instant once that artifact is
+cached.
+
+**In-process integration tests** (`tests/extension_load.rs`, run by `cargo test`):
+- Build the release `cdylib`, append the DuckDB metadata footer (a Rust port of
+  `append_extension_metadata.py`), and `LOAD` it via
+  `quack_rs::testing::InMemoryDb::open_unsigned()` (quack-rs 0.14.0)
+- Assert all 7 functions register and return correct results through live SQL —
+  catching the load/registration/wrong-result class of FFI bugs that unit tests
+  cannot, without needing the external `duckdb` CLI
 
 **E2E tests** (against real DuckDB CLI):
 - 11 workflow test steps per platform (Linux + macOS) in `e2e.yml`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,9 +95,9 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "arrow"
-version = "58.1.0"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d441fdda254b65f3e9025910eb2c2066b6295d9c8ed409522b8d2ace1ff8574c"
+checksum = "378530e55cd479eda3c14eb345310799717e6f76d0c332041e8487022166b471"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -113,9 +113,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-arith"
-version = "58.1.0"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ced5406f8b720cc0bc3aa9cf5758f93e8593cda5490677aa194e4b4b383f9a59"
+checksum = "a0ab212d2c1886e802f51c5212d78ebbcbb0bec980fff9dadc1eb8d45cd0b738"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -127,9 +127,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-array"
-version = "58.1.0"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "772bd34cacdda8baec9418d80d23d0fb4d50ef0735685bd45158b83dfeb6e62d"
+checksum = "cfd33d3e92f207444098c75b42de99d329562be0cf686b307b097cc52b4e999e"
 dependencies = [
  "ahash 0.8.12",
  "arrow-buffer",
@@ -137,7 +137,7 @@ dependencies = [
  "arrow-schema",
  "chrono",
  "half",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "num-complex",
  "num-integer",
  "num-traits",
@@ -145,9 +145,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-buffer"
-version = "58.1.0"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "898f4cf1e9598fdb77f356fdf2134feedfd0ee8d5a4e0a5f573e7d0aec16baa4"
+checksum = "0c6cd424c2693bcdbc150d843dc9d4d137dd2de4782ce6df491ad11a3a0416c0"
 dependencies = [
  "bytes",
  "half",
@@ -157,9 +157,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-cast"
-version = "58.1.0"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0127816c96533d20fc938729f48c52d3e48f99717e7a0b5ade77d742510736d"
+checksum = "4c5aefb56a2c02e9e2b30746241058b85f8983f0fcff2ba0c6d09006e1cded7f"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -179,9 +179,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-data"
-version = "58.1.0"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d10beeab2b1c3bb0b53a00f7c944a178b622173a5c7bcabc3cb45d90238df4"
+checksum = "3c88210023a2bfee1896af366309a3028fc3bcbd6515fa29a7990ee1baa08ee0"
 dependencies = [
  "arrow-buffer",
  "arrow-schema",
@@ -192,9 +192,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-ord"
-version = "58.1.0"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "763a7ba279b20b52dad300e68cfc37c17efa65e68623169076855b3a9e941ca5"
+checksum = "1bffd8fd2579286a5d63bac898159873e5094a79009940bcb42bbfce4f19f1d0"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -205,9 +205,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-row"
-version = "58.1.0"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14fe367802f16d7668163ff647830258e6e0aeea9a4d79aaedf273af3bdcd3e"
+checksum = "bab5994731204603c73ba69267616c50f80780774c6bb0476f1f830625115e0c"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -218,18 +218,18 @@ dependencies = [
 
 [[package]]
 name = "arrow-schema"
-version = "58.1.0"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c30a1365d7a7dc50cc847e54154e6af49e4c4b0fddc9f607b687f29212082743"
+checksum = "f633dbfdf39c039ada1bf9e34c694816eb71fbb7dc78f613993b7245e078a1ed"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "arrow-select"
-version = "58.1.0"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78694888660a9e8ac949853db393af2a8b8fc82c19ce333132dfa2e72cc1a7fe"
+checksum = "8cd065c54172ac787cf3f2f8d4107e0d3fdc26edba76fdf4f4cc170258942222"
 dependencies = [
  "ahash 0.8.12",
  "arrow-array",
@@ -241,9 +241,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-string"
-version = "58.1.0"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61e04a01f8bb73ce54437514c5fd3ee2aa3e8abe4c777ee5cc55853b1652f79e"
+checksum = "29dd7cda3ab9692f43a2e4acc444d760cc17b12bb6d8232ddf64e9bab7c06b42"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -273,9 +273,9 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "base64"
@@ -300,9 +300,9 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "bitvec"
@@ -342,9 +342,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytecheck"
@@ -382,9 +382,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.61"
+version = "1.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
+checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -406,9 +406,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "num-traits",
@@ -614,9 +614,9 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -643,7 +643,7 @@ dependencies = [
 
 [[package]]
 name = "duckdb-behavioral"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "criterion",
  "duckdb",
@@ -654,9 +654,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "equivalent"
@@ -694,13 +694,12 @@ checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "filetime"
-version = "0.2.27"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
 dependencies = [
  "cfg-if",
  "libc",
- "libredox",
 ]
 
 [[package]]
@@ -868,15 +867,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
-
-[[package]]
-name = "hashbrown"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hashlink"
@@ -895,9 +888,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
 dependencies = [
  "bytes",
  "itoa",
@@ -934,9 +927,9 @@ checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "hyper"
-version = "1.9.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1131,7 +1124,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -1141,16 +1134,6 @@ name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
-
-[[package]]
-name = "iri-string"
-version = "0.7.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
-dependencies = [
- "memchr",
- "serde",
-]
 
 [[package]]
 name = "itertools"
@@ -1179,9 +1162,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.97"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
+checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -1285,18 +1268,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
-name = "libredox"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
-dependencies = [
- "bitflags",
- "libc",
- "plain",
- "redox_syscall 0.7.4",
-]
-
-[[package]]
 name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1325,9 +1296,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
 name = "lru-slab"
@@ -1337,9 +1308,9 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "miniz_oxide"
@@ -1353,9 +1324,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "wasi",
@@ -1446,7 +1417,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.18",
+ "redox_syscall",
  "smallvec",
  "windows-link",
 ]
@@ -1468,12 +1439,6 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
-
-[[package]]
-name = "plain"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plotters"
@@ -1590,11 +1555,12 @@ dependencies = [
 
 [[package]]
 name = "quack-rs"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfce2bec24a1d312ce8e5a8e0accfc06331360c33ba11edb7d455f1e975e1bdc"
+checksum = "72a540873815f6072ac20b6b07591370ff5f3ecfa2f76c5ee14900b2aeb694be"
 dependencies = [
  "cc",
+ "duckdb",
  "libduckdb-sys",
  "mutants",
 ]
@@ -1785,15 +1751,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1916,9 +1873,9 @@ dependencies = [
 
 [[package]]
 name = "rust_decimal"
-version = "1.41.0"
+version = "1.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ce901f9a19d251159075a4c37af514c3b8ef99c22e02dd8c19161cf397ee94a"
+checksum = "0c5108e3d4d903e21aac27f12ba5377b6b34f9f44b325e4894c7924169d06995"
 dependencies = [
  "arrayvec",
  "borsh",
@@ -2081,9 +2038,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
@@ -2106,9 +2063,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "simd-adler32"
@@ -2136,9 +2093,9 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -2227,9 +2184,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tar"
-version = "0.4.45"
+version = "0.4.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
 dependencies = [
  "filetime",
  "libc",
@@ -2315,9 +2272,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.1"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -2348,9 +2305,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.11+spec-1.1.0"
+version = "0.25.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
+checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
 dependencies = [
  "indexmap",
  "toml_datetime",
@@ -2384,20 +2341,20 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.8"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "bitflags",
  "bytes",
  "futures-util",
  "http",
  "http-body",
- "iri-string",
  "pin-project-lite",
  "tower",
  "tower-layer",
  "tower-service",
+ "url",
 ]
 
 [[package]]
@@ -2451,9 +2408,9 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.13.2"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-width"
@@ -2493,9 +2450,9 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.23.1"
+version = "1.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+checksum = "d258b83ceec21034727ecee8c382cfa6c3e133699b0742c64571814fb420c9f7"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2567,9 +2524,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.120"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
+checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2581,9 +2538,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.70"
+version = "0.4.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af934872acec734c2d80e6617bbb5ff4f12b052dd8e6332b0817bce889516084"
+checksum = "9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2591,9 +2548,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.120"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
+checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2601,9 +2558,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.120"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
+checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -2614,9 +2571,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.120"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
+checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
 dependencies = [
  "unicode-ident",
 ]
@@ -2657,9 +2614,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.97"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eadbac71025cd7b0834f20d1fe8472e8495821b4e9801eb0a60bd1f19827602"
+checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2941,9 +2898,9 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
 ]
@@ -3069,9 +3026,9 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -3092,18 +3049,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3112,9 +3069,9 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "duckdb-behavioral"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 rust-version = "1.87"
 authors = ["Tom F <tomtom215@users.noreply.github.com>"]
@@ -20,11 +20,16 @@ name = "behavioral"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-quack-rs = "=0.13.0"
+quack-rs = "=0.14.0"
 libduckdb-sys = { version = "=1.10503.1", features = ["loadable-extension"] }
 
 [dev-dependencies]
 duckdb = { version = "=1.10503.1", features = ["bundled"] }
+# `bundled-test` exposes `quack_rs::testing::InMemoryDb`, used by the in-process
+# extension-load integration test (`tests/extension_load.rs`). Its `duckdb/bundled`
+# requirement unifies with the `duckdb` dev-dependency above, so no extra DuckDB
+# build. This feature is dev-only and never reaches the release `.so`.
+quack-rs = { version = "=0.14.0", features = ["bundled-test"] }
 criterion = { version = "0.8", features = ["html_reports"] }
 proptest = "1"
 

--- a/README.md
+++ b/README.md
@@ -385,6 +385,7 @@ version, update `libduckdb-sys`, `TARGET_DUCKDB_VERSION`, and the
 | Metric | Value |
 |---|---|
 | Unit tests | 453 + 1 doc-test |
+| Integration tests | 7 (in-process: real extension loaded via `InMemoryDb`, all 7 functions exercised through SQL) |
 | E2E tests | 11 workflow steps (2 platforms) + 59 SQL queries (against real DuckDB CLI) |
 | Property-based tests | 29 (proptest) |
 | Mutation testing | 88.4% kill rate (130/147, cargo-mutants) |
@@ -428,7 +429,7 @@ cargo build --release
 ## Development
 
 ```bash
-cargo test                  # Unit tests + doc-tests (453 + 1)
+cargo test                  # 453 unit + 7 integration + 1 doc-test
 cargo clippy --all-targets  # Zero warnings required
 cargo fmt -- --check        # Format check
 cargo bench                 # Criterion.rs benchmarks

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -31,7 +31,7 @@ safe Rust. Every `unsafe` block has a `// SAFETY:` documentation comment.
 
 ### Dependency Audit
 
-The extension has exactly **two** runtime dependencies (`quack-rs = "=0.13.0"`
+The extension has exactly **two** runtime dependencies (`quack-rs = "=0.14.0"`
 and `libduckdb-sys = "=1.10503.1"`, both pinned exactly). All dependencies are
 audited via `cargo-deny` in CI for known advisories and license compliance.
 

--- a/deny.toml
+++ b/deny.toml
@@ -26,6 +26,17 @@ allow = [
 ]
 confidence-threshold = 0.8
 
+# `tiny-keccak` is licensed CC0-1.0 (a public-domain dedication). It is a
+# transitive *lockfile* entry only — reachable solely through `ahash`'s optional,
+# never-enabled `compile-time-rng` feature, so it appears in no buildable graph
+# (`cargo tree -i tiny-keccak`, even `--all-features`, shows nothing) and never
+# ships in the extension (the release `.so` links only `libduckdb-sys` +
+# `quack-rs`). Newer cargo-deny still surfaces it from `Cargo.lock`; scope the
+# CC0-1.0 allowance to this one crate rather than globally.
+[[licenses.exceptions]]
+crate = "tiny-keccak"
+allow = ["CC0-1.0"]
+
 [bans]
 multiple-versions = "warn"
 wildcards = "allow"

--- a/description.yml
+++ b/description.yml
@@ -4,7 +4,7 @@
 extension:
   name: behavioral
   description: Behavioral analytics functions inspired by ClickHouse (sessionize, retention, window_funnel, sequence_match, sequence_count, sequence_match_events, sequence_next_node)
-  version: 0.6.0
+  version: 0.7.0
   language: Rust
   build: cargo
   license: MIT

--- a/docs/src/contributing.md
+++ b/docs/src/contributing.md
@@ -46,7 +46,7 @@ configuration and allowed exceptions (FFI callbacks, analytics math casts).
 - **Pure Rust core**: Business logic in top-level modules (`sessionize.rs`,
   `retention.rs`, etc.) with zero FFI dependencies.
 - **FFI bridge via quack-rs SDK**: DuckDB C API registration confined to
-  `src/ffi/`, using [quack-rs](https://crates.io/crates/quack-rs) v0.13.0
+  `src/ffi/`, using [quack-rs](https://crates.io/crates/quack-rs) v0.14.0
   for safe builders (including `returns_logical(LogicalType)` for
   `LIST(T)` returns), state management (`FfiState<T>`), vector I/O
   (`VectorReader`/`VectorWriter`), LIST output (`ListVector`), and type
@@ -102,7 +102,7 @@ cargo build --release
 cp target/release/libbehavioral.so /tmp/behavioral.duckdb_extension
 python3 extension-ci-tools/scripts/append_extension_metadata.py \
   -l /tmp/behavioral.duckdb_extension -n behavioral \
-  -p linux_amd64 -dv v1.5.3 -ev v0.6.0 --abi-type C_STRUCT_UNSTABLE \
+  -p linux_amd64 -dv v1.5.3 -ev v0.7.0 --abi-type C_STRUCT_UNSTABLE \
   -o /tmp/behavioral.duckdb_extension
 
 # Load and test

--- a/docs/src/engineering.md
+++ b/docs/src/engineering.md
@@ -23,7 +23,7 @@ The project spans several distinct engineering disciplines:
 | **Database internals** | DuckDB's segment tree windowing, aggregate function lifecycle (init, update, combine, finalize, destroy), data chunk format |
 | **Algorithm design** | NFA-based pattern matching, recursive descent parsing, greedy funnel search, bitmask-based retention analysis |
 | **Performance engineering** | Cache-aware data structures, algorithmic complexity analysis, Criterion.rs benchmarking with confidence intervals, negative result documentation |
-| **Software quality** | 453 unit tests, 59 E2E SQL queries across 7 test files, property-based testing (proptest), mutation testing (cargo-mutants, 88.4% kill rate), zero clippy warnings under pedantic lints |
+| **Software quality** | 453 unit tests, 7 in-process integration tests (real extension load), 59 E2E SQL queries across 7 test files, property-based testing (proptest), mutation testing (cargo-mutants, 88.4% kill rate), zero clippy warnings under pedantic lints |
 | **CI/CD and release engineering** | Multi-platform builds (Linux x86/ARM, macOS x86/ARM), SemVer validation, artifact attestation, reproducible builds |
 | **Technical writing** | mdBook documentation site, function reference pages, optimization history with measured data, ClickHouse compatibility matrix |
 
@@ -189,6 +189,13 @@ missed:
 3. `window_funnel` returning incorrect results (combine not propagating
    configuration)
 
+As of quack-rs 0.14.0, this same load → register → execute chain also runs
+**in-process inside `cargo test`** (`tests/extension_load.rs`, 7 tests). It
+builds the real release `cdylib`, appends the DuckDB metadata footer, and
+`LOAD`s it via `quack_rs::testing::InMemoryDb::open_unsigned()` — so the entire
+class of FFI-registration bugs above is now caught by the regular test suite,
+not only by the CLI-based E2E job in CI.
+
 **Level 3: Mutation Testing (88.4% kill rate)**
 
 `cargo-mutants` systematically replaces operators, removes branches, and
@@ -311,7 +318,7 @@ these analyses can run as interactive queries rather than batch jobs.
 
 DuckDB's Rust crate does not provide high-level aggregate function
 registration. This project uses the [quack-rs](https://crates.io/crates/quack-rs)
-SDK (v0.13.0) which wraps the raw C API with safe builders
+SDK (v0.14.0) which wraps the raw C API with safe builders
 (including `returns_logical(LogicalType)` for `LIST(T)` return types),
 state management, vector I/O, and LIST output helpers. All 6 aggregate
 functions use the builder for registration. The `sessionize` function

--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -64,7 +64,7 @@ cp target/release/libbehavioral.so /tmp/behavioral.duckdb_extension
 # Append extension metadata
 python3 extension-ci-tools/scripts/append_extension_metadata.py \
   -l /tmp/behavioral.duckdb_extension -n behavioral \
-  -p linux_amd64 -dv v1.5.3 -ev v0.6.0 --abi-type C_STRUCT_UNSTABLE \
+  -p linux_amd64 -dv v1.5.3 -ev v0.7.0 --abi-type C_STRUCT_UNSTABLE \
   -o /tmp/behavioral.duckdb_extension
 ```
 

--- a/docs/src/internals/architecture.md
+++ b/docs/src/internals/architecture.md
@@ -85,7 +85,7 @@ hand-rolled unsafe code from earlier versions.
 
 ### quack-rs SDK
 
-The FFI layer uses [quack-rs](https://crates.io/crates/quack-rs) v0.13.0,
+The FFI layer uses [quack-rs](https://crates.io/crates/quack-rs) v0.14.0,
 a Rust SDK for DuckDB loadable extensions. It provides:
 
 - **`AggregateFunctionSetBuilder`**: Safe registration of function sets with

--- a/docs/src/operations/security.md
+++ b/docs/src/operations/security.md
@@ -34,7 +34,7 @@ The extension has exactly **two** runtime dependencies:
 
 | Crate | Version | Purpose |
 |-------|---------|---------|
-| `quack-rs` | `=0.13.0` | Rust SDK for DuckDB loadable extensions — entry point macro, aggregate builders, safe state management, vector I/O |
+| `quack-rs` | `=0.14.0` | Rust SDK for DuckDB loadable extensions — entry point macro, aggregate builders, safe state management, vector I/O |
 | `libduckdb-sys` | `=1.10503.1` | DuckDB C API bindings (re-exported by quack-rs; kept explicitly for `sessionize` window function FFI) |
 
 Both versions are **pinned exactly** to prevent silent dependency updates.
@@ -52,6 +52,7 @@ release extension binary:
 | Crate | Purpose |
 |-------|---------|
 | `duckdb` | In-memory connection for unit tests |
+| `quack-rs` (`bundled-test`) | `InMemoryDb` for the in-process extension-load integration test |
 | `criterion` | Benchmarking framework |
 | `proptest` | Property-based testing |
 
@@ -100,7 +101,7 @@ Release artifacts include:
 sha256sum -c SHA256SUMS.txt
 
 # Verify GitHub attestation (requires gh CLI)
-gh attestation verify behavioral-v0.6.0-linux_amd64.tar.gz \
+gh attestation verify behavioral-v0.7.0-linux_amd64.tar.gz \
   --repo tomtom215/duckdb-behavioral
 ```
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -36,7 +36,7 @@ set -euo pipefail
 readonly DUCKDB_RELEASE_VERSION="v1.5.3"
 
 # Extension version from Cargo.toml
-readonly EXT_VERSION="v0.6.0"
+readonly EXT_VERSION="v0.7.0"
 
 # Extension name
 readonly EXT_NAME="behavioral"

--- a/src/ffi/mod.rs
+++ b/src/ffi/mod.rs
@@ -5,7 +5,7 @@
 //!
 //! # Architecture
 //!
-//! All modules except [`sessionize`] use the `quack-rs` v0.13 SDK for
+//! All modules except [`sessionize`] use the `quack-rs` v0.14 SDK for
 //! registration, state management, and vector I/O:
 //!
 //! - [`quack_rs::aggregate::AggregateFunctionSetBuilder`] — registers function

--- a/tests/extension_load.rs
+++ b/tests/extension_load.rs
@@ -1,0 +1,393 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Tom F. (https://github.com/tomtom215/duckdb-behavioral)
+
+//! In-process integration tests that load the **real** loadable extension into a
+//! live `DuckDB` instance and exercise every function through actual SQL.
+//!
+//! # Why this exists
+//!
+//! Unit tests exercise the pure-Rust cores and the FFI callbacks in isolation
+//! (via `MockVectorReader`/`MockVectorWriter` and `AggregateTestHarness`), but
+//! they cannot exercise the *registration* path — the code that runs when
+//! `DuckDB` actually `LOAD`s the compiled `.duckdb_extension`. That path has
+//! historically hidden the most dangerous bugs: a SEGFAULT on load, functions
+//! silently failing to register, and a function returning wrong results — all
+//! while the unit suite was green (see `CLAUDE.md`, "E2E testing is
+//! non-negotiable").
+//!
+//! `quack_rs::testing::InMemoryDb::open_unsigned()` (new in quack-rs 0.14.0)
+//! closes that gap *inside `cargo test`*: it opens an in-memory `DuckDB` with
+//! `allow_unsigned_extensions` enabled, so we can `LOAD` the locally-built
+//! (and therefore unsigned) artifact and assert on real query output — no
+//! external `duckdb` CLI required. This is the same end-to-end path a user hits
+//! with `LOAD behavioral`, run in-process.
+//!
+//! # How it works
+//!
+//! 1. Build the release `cdylib` (`cargo build --release --lib`), once.
+//! 2. Append the `DuckDB` extension metadata footer to the raw shared library,
+//!    producing a `.duckdb_extension` (mirrors `append_extension_metadata.py`).
+//! 3. Open `InMemoryDb::open_unsigned()`, relax the metadata-mismatch check, and
+//!    `LOAD` the artifact.
+//! 4. Run SQL covering all seven functions and assert on the results — the same
+//!    expectations encoded in `test/sql/*.test`.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::OnceLock;
+
+use quack_rs::testing::InMemoryDb;
+
+/// `DuckDB` release version this extension targets (the `-dv` metadata field for
+/// the `C_STRUCT_UNSTABLE` ABI). Kept in sync with the `Makefile` /
+/// `.github/workflows/e2e.yml`.
+const DUCKDB_VERSION: &str = "v1.5.3";
+/// Extension version metadata field (`-ev`); matches `Cargo.toml`'s `version`.
+const EXTENSION_VERSION: &str = "v0.7.0";
+/// ABI type for a quack-rs / `libduckdb-sys` C-struct extension.
+const ABI_TYPE: &str = "C_STRUCT_UNSTABLE";
+
+/// The `DuckDB` platform triple for the host target. With
+/// `allow_extensions_metadata_mismatch=true` the value need not match the host
+/// exactly, but we still emit the correct one so the artifact is identical to
+/// what CI ships.
+const fn duckdb_platform() -> &'static str {
+    match (cfg!(target_os = "macos"), cfg!(target_arch = "aarch64")) {
+        (true, true) => "osx_arm64",
+        (true, false) => "osx_amd64",
+        (false, true) => "linux_arm64",
+        (false, false) => "linux_amd64",
+    }
+}
+
+/// Builds the release `cdylib` (no-op if already current) and returns its path.
+fn build_release_cdylib() -> PathBuf {
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    // `CARGO` is set by cargo when running test binaries; fall back to `cargo`.
+    let cargo = std::env::var("CARGO").unwrap_or_else(|_| "cargo".to_string());
+
+    let status = Command::new(&cargo)
+        .args(["build", "--release", "--lib"])
+        .current_dir(manifest_dir)
+        .status()
+        .expect("failed to spawn `cargo build --release --lib`");
+    assert!(status.success(), "`cargo build --release --lib` failed");
+
+    let target_dir =
+        std::env::var("CARGO_TARGET_DIR").unwrap_or_else(|_| format!("{manifest_dir}/target"));
+    // `[lib] name = "behavioral"` → `libbehavioral.{so,dylib}`.
+    let lib_file = if cfg!(target_os = "macos") {
+        "libbehavioral.dylib"
+    } else {
+        "libbehavioral.so"
+    };
+    let path = PathBuf::from(target_dir).join("release").join(lib_file);
+    assert!(
+        path.exists(),
+        "built cdylib not found at {} — check `[lib] name`",
+        path.display()
+    );
+    path
+}
+
+/// Encodes a metadata field as a 32-byte, NUL-padded ASCII block.
+fn padded_field(value: &str) -> [u8; 32] {
+    assert!(
+        value.len() <= 32,
+        "metadata field {value:?} exceeds 32 bytes"
+    );
+    let mut field = [0u8; 32];
+    field[..value.len()].copy_from_slice(value.as_bytes());
+    field
+}
+
+/// Appends the `DuckDB` extension metadata footer to `raw_lib`, writing the
+/// resulting `.duckdb_extension` to `out`.
+///
+/// This is a byte-for-byte port of `extension-ci-tools`'
+/// `append_extension_metadata.py`: a WebAssembly custom-section header
+/// (`duckdb_signature`), eight 32-byte fields written FIELD8→FIELD1, and a
+/// 256-byte zero-filled signature slot.
+fn append_metadata(raw_lib: &Path, out: &Path) {
+    let mut bytes = std::fs::read(raw_lib).expect("read raw cdylib");
+
+    // ── start signature (Wasm custom section so Wasm binaries stay valid) ──
+    bytes.push(0x00); // custom section id
+    bytes.push(147); // LEB128 low byte of 531 (1 + 16 + 2 + 8*32 + 256)
+    bytes.push(4); // LEB128 high byte of 531
+    bytes.push(16); // length of the section name
+    bytes.extend_from_slice(b"duckdb_signature"); // 16-byte section name
+    bytes.push(128); // LEB128 low byte of 512
+    bytes.push(4); // LEB128 high byte of 512
+
+    // ── eight 32-byte fields, written FIELD8 (last) → FIELD1 (first) ──
+    bytes.extend_from_slice(&padded_field("")); // FIELD8 (unused)
+    bytes.extend_from_slice(&padded_field("")); // FIELD7 (unused)
+    bytes.extend_from_slice(&padded_field("")); // FIELD6 (unused)
+    bytes.extend_from_slice(&padded_field(ABI_TYPE)); // FIELD5 abi_type
+    bytes.extend_from_slice(&padded_field(EXTENSION_VERSION)); // FIELD4 ext version
+    bytes.extend_from_slice(&padded_field(DUCKDB_VERSION)); // FIELD3 duckdb version
+    bytes.extend_from_slice(&padded_field(duckdb_platform())); // FIELD2 platform
+    bytes.extend_from_slice(&padded_field("4")); // FIELD1 header signature
+
+    // ── 256-byte signature slot (unsigned → all zeroes) ──
+    bytes.extend_from_slice(&[0u8; 256]);
+
+    std::fs::write(out, &bytes).expect("write .duckdb_extension");
+}
+
+/// Builds + signs the extension once per test process and returns its path.
+///
+/// The signed artifact name is namespaced by process id. `cargo nextest` runs
+/// each test in its own process, so several may build/sign concurrently; a
+/// per-pid filename keeps each writer on its own file (the underlying
+/// `cargo build` is itself idempotent and serialized by cargo's own lock).
+fn extension_path() -> &'static Path {
+    static PATH: OnceLock<PathBuf> = OnceLock::new();
+    PATH.get_or_init(|| {
+        let raw = build_release_cdylib();
+        let out = raw.with_file_name(format!(
+            "behavioral.test.{}.duckdb_extension",
+            std::process::id()
+        ));
+        append_metadata(&raw, &out);
+        out
+    })
+    .as_path()
+}
+
+/// Opens a fresh in-memory `DuckDB` with the behavioral extension loaded.
+fn load_extension() -> InMemoryDb {
+    let db = InMemoryDb::open_unsigned().expect("open in-memory DuckDB (unsigned)");
+    // Locally-built artifacts carry host platform / version metadata that need
+    // not match the in-process DuckDB; relax the check (mirrors the documented
+    // `InMemoryDb::open_unsigned` workflow).
+    db.execute_batch("SET allow_extensions_metadata_mismatch=true")
+        .expect("relax metadata mismatch");
+    let load = format!("LOAD '{}'", extension_path().display());
+    db.execute_batch(&load)
+        .unwrap_or_else(|e| panic!("LOAD failed for {}: {e}", extension_path().display()));
+    db
+}
+
+/// The extension loads without error and registers all seven functions in the
+/// catalog. A missing registration here is exactly the class of bug that passed
+/// the unit suite while shipping a broken extension.
+#[test]
+fn loads_and_registers_all_functions() {
+    let db = load_extension();
+    for func in [
+        "sessionize",
+        "retention",
+        "window_funnel",
+        "sequence_match",
+        "sequence_count",
+        "sequence_match_events",
+        "sequence_next_node",
+    ] {
+        let count: i64 = db
+            .query_one(&format!(
+                "SELECT count(*) FROM duckdb_functions() WHERE function_name = '{func}'"
+            ))
+            .unwrap_or_else(|e| panic!("catalog query for {func} failed: {e}"));
+        assert!(count >= 1, "function `{func}` is not registered");
+    }
+}
+
+#[test]
+fn sessionize_window_function() {
+    let db = load_extension();
+    db.execute_batch(
+        "CREATE TABLE s(ts TIMESTAMP);
+         INSERT INTO s VALUES
+            ('2024-01-01 00:00:00'), ('2024-01-01 00:05:00'),
+            ('2024-01-01 00:10:00'), ('2024-01-01 02:00:00'),
+            ('2024-01-01 02:05:00');",
+    )
+    .unwrap();
+    let ids: Vec<i64> = db
+        .conn()
+        .prepare(
+            "SELECT sessionize(ts, INTERVAL '30 minutes') OVER (ORDER BY ts) FROM s ORDER BY ts",
+        )
+        .unwrap()
+        .query_map([], |r| r.get(0))
+        .unwrap()
+        .collect::<Result<_, _>>()
+        .unwrap();
+    assert_eq!(ids, vec![1, 1, 1, 2, 2]);
+}
+
+#[test]
+fn retention_aggregate() {
+    let db = load_extension();
+    db.execute_batch(
+        "CREATE TABLE a(user_id INTEGER, day DATE);
+         INSERT INTO a VALUES
+            (1,'2024-01-01'),(1,'2024-01-02'),(1,'2024-01-03'),
+            (2,'2024-01-01'),(2,'2024-01-03'),
+            (3,'2024-01-01');",
+    )
+    .unwrap();
+    let q = |uid: i32| {
+        format!(
+            "SELECT CAST(retention(day='2024-01-01', day='2024-01-02', day='2024-01-03') AS VARCHAR) \
+             FROM a WHERE user_id = {uid}"
+        )
+    };
+    let r1: String = db.query_one(&q(1)).unwrap();
+    let r2: String = db.query_one(&q(2)).unwrap();
+    let r3: String = db.query_one(&q(3)).unwrap();
+    assert_eq!(r1, "[true, true, true]");
+    assert_eq!(r2, "[true, false, true]");
+    assert_eq!(r3, "[true, false, false]");
+}
+
+#[test]
+fn window_funnel_aggregate() {
+    let db = load_extension();
+    db.execute_batch(
+        "CREATE TABLE f(user_id INTEGER, ts TIMESTAMP, event VARCHAR);
+         INSERT INTO f VALUES
+            (1,'2024-01-01 00:00:00','view'),(1,'2024-01-01 00:05:00','cart'),(1,'2024-01-01 00:10:00','purchase'),
+            (2,'2024-01-01 00:00:00','view'),(2,'2024-01-01 00:05:00','cart'),
+            (3,'2024-01-01 00:00:00','view'),(3,'2024-01-01 05:00:00','cart');",
+    )
+    .unwrap();
+    let rows: Vec<(i32, i32)> = db
+        .conn()
+        .prepare(
+            "SELECT user_id, window_funnel(INTERVAL '1 hour', ts, \
+                event='view', event='cart', event='purchase') \
+             FROM f GROUP BY user_id ORDER BY user_id",
+        )
+        .unwrap()
+        .query_map([], |r| Ok((r.get(0)?, r.get(1)?)))
+        .unwrap()
+        .collect::<Result<_, _>>()
+        .unwrap();
+    assert_eq!(rows, vec![(1, 3), (2, 2), (3, 1)]);
+
+    // strict_increase mode (named-mode overload exercises the VARCHAR arg path).
+    let strict: i32 = db
+        .query_one(
+            "SELECT window_funnel(INTERVAL '1 hour', 'strict_increase', ts, \
+                event='view', event='cart', event='purchase') \
+             FROM f WHERE user_id = 1",
+        )
+        .unwrap();
+    assert_eq!(strict, 3);
+}
+
+#[test]
+fn sequence_match_and_count_aggregates() {
+    let db = load_extension();
+    db.execute_batch(
+        "CREATE TABLE c(user_id INTEGER, ts TIMESTAMP, is_view BOOLEAN, is_cart BOOLEAN, is_purchase BOOLEAN);
+         INSERT INTO c VALUES
+            (1,'2024-01-01 00:00:00',true,false,false),(1,'2024-01-01 00:05:00',false,true,false),(1,'2024-01-01 00:10:00',false,false,true),
+            (2,'2024-01-01 00:00:00',true,false,false),(2,'2024-01-01 00:05:00',true,false,false),
+            (3,'2024-01-01 00:00:00',true,false,false),(3,'2024-01-01 00:05:00',false,false,true);",
+    )
+    .unwrap();
+
+    let matches: Vec<(i32, bool)> = db
+        .conn()
+        .prepare(
+            "SELECT user_id, sequence_match('(?1)(?2)(?3)', ts, is_view, is_cart, is_purchase) \
+             FROM c GROUP BY user_id ORDER BY user_id",
+        )
+        .unwrap()
+        .query_map([], |r| Ok((r.get(0)?, r.get(1)?)))
+        .unwrap()
+        .collect::<Result<_, _>>()
+        .unwrap();
+    assert_eq!(matches, vec![(1, true), (2, false), (3, false)]);
+
+    let counts: Vec<(i32, i64)> = db
+        .conn()
+        .prepare(
+            "SELECT user_id, sequence_count('(?1).*(?3)', ts, is_view, is_cart, is_purchase) \
+             FROM c GROUP BY user_id ORDER BY user_id",
+        )
+        .unwrap()
+        .query_map([], |r| Ok((r.get(0)?, r.get(1)?)))
+        .unwrap()
+        .collect::<Result<_, _>>()
+        .unwrap();
+    assert_eq!(counts, vec![(1, 1), (2, 0), (3, 1)]);
+}
+
+#[test]
+fn sequence_match_events_aggregate() {
+    let db = load_extension();
+    db.execute_batch(
+        "CREATE TABLE e(user_id INTEGER, ts TIMESTAMP, c1 BOOLEAN, c2 BOOLEAN, c3 BOOLEAN);
+         INSERT INTO e VALUES
+            (1,'2024-01-01 00:00:00',true,false,false),(1,'2024-01-01 00:05:00',false,true,false),(1,'2024-01-01 00:10:00',false,false,true),
+            (2,'2024-01-01 00:00:00',true,false,false),(2,'2024-01-01 00:05:00',true,false,false);",
+    )
+    .unwrap();
+    let matched: String = db
+        .query_one(
+            "SELECT CAST(sequence_match_events('(?1)(?2)(?3)', ts, c1, c2, c3) AS VARCHAR) \
+             FROM e WHERE user_id = 1",
+        )
+        .unwrap();
+    assert_eq!(
+        matched,
+        "['2024-01-01 00:00:00', '2024-01-01 00:05:00', '2024-01-01 00:10:00']"
+    );
+    let empty: String = db
+        .query_one(
+            "SELECT CAST(sequence_match_events('(?1)(?2)(?3)', ts, c1, c2, c3) AS VARCHAR) \
+             FROM e WHERE user_id = 2",
+        )
+        .unwrap();
+    assert_eq!(empty, "[]");
+}
+
+#[test]
+fn sequence_next_node_aggregate() {
+    let db = load_extension();
+    db.execute_batch(
+        "CREATE TABLE p(user_id INTEGER, ts TIMESTAMP, page VARCHAR, is_home BOOLEAN, is_product BOOLEAN);
+         INSERT INTO p VALUES
+            (1,'2024-01-01 00:00:00','home',true,false),(1,'2024-01-01 00:01:00','product',false,true),(1,'2024-01-01 00:02:00','cart',false,false),
+            (2,'2024-01-01 00:00:00','home',true,false),(2,'2024-01-01 00:01:00','search',false,false),(2,'2024-01-01 00:02:00','product',false,true);",
+    )
+    .unwrap();
+    // forward / first_match: what comes after the first home?
+    let rows: Vec<(i32, String)> = db
+        .conn()
+        .prepare(
+            "SELECT user_id, sequence_next_node('forward','first_match', ts, page, is_home, is_home) \
+             FROM p GROUP BY user_id ORDER BY user_id",
+        )
+        .unwrap()
+        .query_map([], |r| Ok((r.get(0)?, r.get(1)?)))
+        .unwrap()
+        .collect::<Result<_, _>>()
+        .unwrap();
+    assert_eq!(
+        rows,
+        vec![(1, "product".to_string()), (2, "search".to_string())]
+    );
+
+    // backward / first_match: what comes before the first product?
+    let back: Vec<(i32, String)> = db
+        .conn()
+        .prepare(
+            "SELECT user_id, sequence_next_node('backward','first_match', ts, page, is_product, is_product) \
+             FROM p GROUP BY user_id ORDER BY user_id",
+        )
+        .unwrap()
+        .query_map([], |r| Ok((r.get(0)?, r.get(1)?)))
+        .unwrap()
+        .collect::<Result<_, _>>()
+        .unwrap();
+    assert_eq!(
+        back,
+        vec![(1, "home".to_string()), (2, "search".to_string())]
+    );
+}


### PR DESCRIPTION
## Summary

Updates the SDK to the new **quack-rs v0.14.0** release and hardens the testing and supply-chain story end to end. The extension's public surface (the 7 SQL functions) is unchanged — this is a dependency + testing + docs upgrade.

### quack-rs `0.13.0` → `0.14.0`
Every public API this crate uses (`AggregateFunctionSetBuilder`, `FfiState`, `VectorReader`/`VectorWriter`, `ListVector`, `LogicalType::list`, `returns_logical`, `AggregateTestHarness`, `Connection`/`Registrar`, `entry_point_v2!`) is unchanged — **zero changes to existing source**. v0.14.0 is purely additive: `wasm32-unknown-emscripten` (DuckDB-WASM) support, a `bundled-test-prebuilt` feature, and `InMemoryDb::open_unsigned()`.

### New: in-process extension-load integration tests (`tests/extension_load.rs`, 7 tests)
The headline improvement. They build the **real release `cdylib`**, append the DuckDB metadata footer (a Rust port of `append_extension_metadata.py`), and `LOAD` it into an in-memory DuckDB via quack-rs 0.14.0's `testing::InMemoryDb::open_unsigned()`, then exercise **all seven functions through live SQL** — inside `cargo test`, with no external `duckdb` CLI.

This closes the long-standing gap CLAUDE.md flags as the #1 testing risk: the *segfault-on-load / silent-non-registration / wrong-result* class of FFI bugs that unit tests cannot reach. Adds the `quack-rs` `bundled-test` dev-feature, which unifies with the existing `duckdb/bundled` dev-dependency (no extra DuckDB build) and never reaches the release `.so`.

### Dependencies (`cargo update`)
- `tar 0.4.45 → 0.4.46` — resolves **GHSA-3pv8-6f4r-ffg2** ("PAX header desynchronization", moderate; a `libduckdb-sys` build-dependency). This is the open Dependabot alert on `main`.
- `cc 1.2.61 → 1.2.63`, `shlex 1.3.0 → 2.0.1`, `arrow 58.1 → 58.3`, plus routine transitive bumps.
- All direct deps are at their latest versions; the only held-back transitive crate is `comfy-table` (constrained by the `duckdb` dev-dependency). All bumped crates declare MSRV ≤ 1.85, so the project MSRV stays **1.87**.
- `deny.toml`: tightly-scoped `CC0-1.0` exception for `tiny-keccak` — a phantom `Cargo.lock` entry behind `ahash`'s optional, never-enabled `compile-time-rng` feature (absent from every buildable graph and from the shipped `.so`), so modern `cargo-deny` releases pass the license gate.

### Version + docs
Bumps the extension to **v0.7.0** (the project convention: each quack-rs upgrade gets a version bump) and updates every version reference across `README.md`, `CLAUDE.md`, `SECURITY.md`, `description.yml`, `scripts/setup.sh`, `docs/src/**`, the issue/PR templates, and the community-submission workflow + `CHANGELOG.md`. The `description.yml` `ref` is intentionally left for the release step.

## Verification (run locally, directly)

| Gate | Result |
|---|---|
| `cargo test` | 453 unit + **7 integration** + 1 doc-test — all pass |
| `cargo nextest run --profile ci` | **460** pass (CI's exact process-per-test path) |
| `cargo clippy --all-targets -- -D warnings` | 0 warnings |
| `cargo fmt -- --check` | clean |
| `cargo doc --no-deps --document-private-items` (`-Dwarnings`) | clean |
| `cargo deny check advisories bans licenses sources` | all **ok** |
| `cargo bench --no-run` | 7/7 benches compile |
| MSRV 1.87 | safe — every bumped crate declares MSRV ≤ 1.85 |

The mature core algorithm modules are intentionally left untouched — they're exhaustively (mutation-guided) tested already; changing them would be churn, not improvement.

https://claude.ai/code/session_01XrxjxwWKPZWTspc1UBQScN

---
_Generated by [Claude Code](https://claude.ai/code/session_01XrxjxwWKPZWTspc1UBQScN)_